### PR TITLE
update build macros to support intel mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "cognitive-services-speech-sdk-rs"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bindgen",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cognitive-services-speech-sdk-rs"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Adam Bezecny <adam.bezecny@gmail.com>"]
 edition = "2018"
 description = "Rust bindings for Microsoft Speech SDK."

--- a/build.rs
+++ b/build.rs
@@ -128,7 +128,8 @@ fn main() {
 
 #[cfg(any(
     all(target_os = "macos", target_arch = "aarch64"),
-    all(target_os = "macos", target_arch = "arm")
+    all(target_os = "macos", target_arch = "arm"),
+    all(target_os = "macos", target_arch = "x86_64")
 ))]
 fn main() {
     let speek_sdk_root = env::var("MACOS_SPEECHSDK_ROOT").expect(


### PR DESCRIPTION
Wasn't sure why the `clang_arg` line in `build.rs` depended on the target arch, but I was able to build and run an example app without adding `x86_64` to the `cfg` attribute so I didn't update it. 