### PR TITLE
Implement std::error::Error trait for error::Error struct.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,14 @@ pub struct Error {
     pub caused_by: ErrorRootCause,
 }
 
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} caused by: {:?}", self.message, self.caused_by)
+    }
+}
+
 impl Error {
     /// Creates new error from custom message and underlying root cause.
     pub fn new(message: String, caused_by: ErrorRootCause) -> Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl std::error::Error for Error {}
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} caused by: {:?}", self.message, self.caused_by)
+        write!(f, "{}", self.message)
     }
 }
 


### PR DESCRIPTION
This PR made one small change:
Impl `stdError` trait for the `error::Error` struct, so that it can work well with the `anyhow::Result<T>` return type.
e.g.
```rust
pub async fn transcribe_speaker_output(&self) -> anyhow::Result<()> {
   let wave_format = AudioStreamFormat::get_wave_format_pcm(16000, Some(16), Some(1))?;
   let mut pull_input_stream = PullAudioInputStream::from_format(&wave_format)?;
   let audio_config = AudioConfig::from_stream_input(&pull_input_stream)?;
   ...
}
```