### PR TITLE
Allow consumers to not automatically download the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,10 +116,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -191,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
@@ -237,13 +246,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cognitive-services-speech-sdk-rs"
 version = "1.0.0"
 dependencies = [
  "bindgen",
  "env_logger",
+ "flate2",
  "log",
+ "tar",
  "tokio",
+ "ureq",
  "zip",
 ]
 
@@ -255,9 +276,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "cpufeatures"
@@ -267,6 +288,21 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -294,12 +330,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -353,13 +406,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.28"
+name = "filetime"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -370,6 +445,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -415,6 +501,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,9 +551,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libloading"
@@ -470,6 +566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,9 +583,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -490,6 +596,16 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
 
 [[package]]
 name = "memchr"
@@ -566,9 +682,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -576,39 +692,32 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -657,18 +766,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -701,6 +813,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +853,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,18 +891,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -756,17 +914,6 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -789,6 +936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,13 +949,19 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "subtle"
@@ -819,6 +978,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -839,6 +1009,21 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -871,16 +1056,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -899,6 +1139,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -1052,41 +1301,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
-name = "zip"
-version = "0.6.6"
+name = "xattr"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
+
+[[package]]
+name = "zip"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6cb8909b2e8e6733c9ef67d35be1a27105644d362aafb5f8b2ba395727adf6"
 dependencies = [
  "aes",
+ "arbitrary",
  "byteorder",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
  "flate2",
  "hmac",
+ "lzma-rs",
  "pbkdf2",
  "sha1",
  "time",
+ "zopfli",
  "zstd",
 ]
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "5c1f48f3508a3a3f2faee01629564400bc12260f6214a056d06a3aaaa6ef0736"
+dependencies = [
+ "crc32fast",
+ "log",
+ "simd-adler32",
+ "typed-arena",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,15 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,36 +158,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
-dependencies = [
- "jobserver",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "cexpr"
@@ -225,16 +179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,15 +187,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -275,36 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,29 +225,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "deflate64"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ace6c86376be0b6cdcf3fb41882e81d94b31587573d1cfa9d01cd06bba210d"
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_arbitrary"
@@ -353,17 +239,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -424,7 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -435,16 +309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -477,15 +341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,30 +366,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -566,16 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,16 +423,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
-]
 
 [[package]]
 name = "memchr"
@@ -648,12 +465,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num_cpus"
@@ -704,16 +515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,18 +525,6 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -890,37 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.200"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.200"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,12 +692,6 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
@@ -992,25 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,18 +787,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
@@ -1127,12 +848,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -1323,60 +1038,10 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e6cb8909b2e8e6733c9ef67d35be1a27105644d362aafb5f8b2ba395727adf6"
 dependencies = [
- "aes",
  "arbitrary",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
  "flate2",
- "hmac",
- "lzma-rs",
- "pbkdf2",
- "sha1",
- "time",
- "zopfli",
- "zstd",
-]
-
-[[package]]
-name = "zopfli"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f48f3508a3a3f2faee01629564400bc12260f6214a056d06a3aaaa6ef0736"
-dependencies = [
- "crc32fast",
- "log",
- "simd-adler32",
- "typed-arena",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ bindgen = "0.69.4"
 flate2 = "1.0.28"
 tar = "0.4.40"
 ureq = "2.9.6"
-zip = "1.1.1"
+zip = { version = "1.1.1", default-features = false, features = ["deflate", "deflate64"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ exclude = [
 repository = "https://github.com/jabber-tools/cognitive-services-speech-sdk-rs/"
 documentation = "https://jabber-tools.github.io/cognitive_services_speech_sdk_rs/doc/1.0.0/cognitive_services_speech_sdk_rs/index.html"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 log = "0.4"
 env_logger = "0.11.3"
-tokio = {version = "1.37.0", features = ["full"]} 
+tokio = { version = "1.37.0", features = ["full"] }
 
 [build-dependencies]
 bindgen = "0.69.4"
-zip = "0.6.6"
+flate2 = "1.0.28"
+tar = "0.4.40"
+ureq = "2.9.6"
+zip = "1.1.1"

--- a/README.md
+++ b/README.md
@@ -123,18 +123,15 @@ sudo apt-get update
 sudo apt-get install clang build-essential libssl1.0.0 libasound2 wget
 ```
 
-Build is generating Rust bindings for Speech SDK native functions. These are already prebuilt and put into *ffi/bindings.rs* file. In most cases it is not necessary to regenerate them. Set following to skip bindings regeneration:
+By default, the build automatically downloads the SDK and generates Rust bindings to the native functions.
 
-```
-export MS_COG_SVC_SPEECH_SKIP_BINDGEN=1
-cargo build
-```
-
-Build process will download MS Speech SDK into target folder. From here you can copy it into other folder, e.g. ./SpeechSDK. When running compiled binary dynamic linking should be used:
+When you ship your compiled executable you must include the SDK library and dynamically link to it at runt ime.
+The build process will download MS Speech SDK into target folder. From here you can copy it into other folder, e.g. ./SpeechSDK.
+If you wish to build against a pre-installed SDK, set the environment variable `MS_COG_SVC_SPEECH_SDK_DIR` to the directory where you downloaded and extracted the SDK.
 
 Linux:
 ```
-export LD_LIBRARY_PATH=/Users/xxx/cognitive-services-speech-sdk-rs/SpeechSDK/macOS/sdk_output/MicrosoftCognitiveServicesSpeech.xcframework/macos-arm64_x86_64
+export LD_LIBRARY_PATH=/home/xxx/cognitive-services-speech-sdk-rs/SpeechSDK/lib/x64/
 ```
 
 MacOS:
@@ -145,6 +142,13 @@ export DYLD_FALLBACK_FRAMEWORK_PATH=/Users/xxx/cognitive-services-speech-sdk-rs/
 Windows (pointing to SpeechSDK directly in target folder):
 ```
 set PATH=%PATH%;"C:\Users\xxx\cognitive-services-speech-sdk-rs\target\debug\build\cognitive-services-speech-sdk-rs-b9c946c378fbb4f1\out\sdk_output\runtimes\win-x64\native"
+```
+
+It's best practice to generate the bindings on your machine so that they match your SDK version and system perfectly, however if you wish to skip this and use the pre-generated bindings, set the environment variable `MS_COG_SVC_SPEECH_SKIP_BINDGEN` to `1` when building.
+For example:
+```
+export MS_COG_SVC_SPEECH_SKIP_BINDGEN=1
+cargo build
 ```
 
 ## Added in this version

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ By default, the build automatically downloads the SDK and generates Rust binding
 
 When you ship your compiled executable you must include the SDK library and dynamically link to it at runt ime.
 The build process will download MS Speech SDK into target folder. From here you can copy it into other folder, e.g. ./SpeechSDK.
-If you wish to build against a pre-installed SDK, set the environment variable `MS_COG_SVC_SPEECH_SDK_DIR` to the directory where you downloaded and extracted the SDK.
+If you wish to build against a pre-installed SDK, set the environment variable `MS_COG_SVC_SPEECH_LIB_DIR` to a directory containing the Speech SDK native library and `MS_COG_SVC_SPEECH_INCLUDE_DIR` to a directory containing the Speech SDK C API header files.
 
 Linux:
 ```

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,10 @@ use flate2::read::GzDecoder;
 const SPEECH_SDK_VERSION: &str = "1.37.0";
 
 fn main() {
+    // Tell cargo that we might emit the `bindgen` cfg flag so it gets linted
+    // correctly.
+    println!("cargo::rustc-check-cfg=cfg(bindgen)");
+
     if env_var("DOCS_RS").is_some() {
         // Skip linking and bindgen when building docs as docs.rs won't have the
         // dependency present and can't download it.

--- a/build.rs
+++ b/build.rs
@@ -70,9 +70,12 @@ fn main() {
     }
     println!("cargo::rustc-cfg=bindgen");
 
-    let Some(include_dir) = link_params.include_dir else {
-        // Note this is only possible to hit if the user has specified the lib dir.
-        panic!("Include directory must be specified with MS_COG_SVC_SPEECH_INCLUDE_DIR");
+    let include_dir = match link_params.include_dir {
+        Some(include_dir) => include_dir,
+        _ => {
+            // Note this is only possible to hit if the user has specified the lib dir.
+            panic!("Include directory must be specified with MS_COG_SVC_SPEECH_INCLUDE_DIR");
+        }
     };
     let bindings_builder = bindgen::Builder::default()
         .header("c_api/wrapper.h")
@@ -86,7 +89,7 @@ fn main() {
     let bindings_builder = bindings_builder
         // use gcc to find correct include path for stddef.h
         .clang_arg(
-            Command::new("gcc")
+            std::process::Command::new("gcc")
                 .arg("--print-file-name=include")
                 .output()
                 .map(|o| format!("-I{}", String::from_utf8_lossy(&o.stdout).trim()))

--- a/build.rs
+++ b/build.rs
@@ -1,116 +1,76 @@
-// build.rs
-#[allow(unused_imports)]
 use std::{
-    env, fs,
+    ffi::OsString,
+    fs,
     path::{Path, PathBuf},
-    process::Command,
     str,
 };
 
+use flate2::read::GzDecoder;
+
+// If you update this, run a build with MS_COG_SVC_SPEECH_UPDATE_BINDINGS=1
+// to update the bindings.rs file.
 const SPEECH_SDK_VERSION: &str = "1.37.0";
 
-fn download_file(url: &str, dst: &str) {
-    Command::new("curl")
-        .args(["-SL", url, "-o", dst, "--ssl-no-revoke"])
-        .status()
-        .expect("failed to download Speech SDK!");
-}
-
-#[cfg(target_os = "linux")]
 fn main() {
-    let linux_sdk_url = format!(
-        "https://csspeechstorage.blob.core.windows.net/drop/{SPEECH_SDK_VERSION}/SpeechSDK-Linux-{SPEECH_SDK_VERSION}.tar.gz");
-
-    // Build scripts should not modify any files outside of the `OUT_DIR` directory,
-    // othersize `cargo publish` will fail.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    // copying SpeechSDK from local folder just worked fine but crates.io allows
-    // only 10 MB to be uploaded per crate. Because of that SpeechSDK shared libraries
-    // were moved to separate repository (https://github.com/jabber-tools/cognitive-services-speech-sdk-rs-files)
-    // and must be downloaded during build from there.
-    /*
-    fs::copy(
-        "./SpeechSDK/lib/x64/libMicrosoft.CognitiveServices.Speech.core.so",
-        Path::new(&out_path).join("libMicrosoft.CognitiveServices.Speech.core.so"),
-    )
-    .unwrap();
-    fs::copy(
-        "./SpeechSDK/lib/x64/libMicrosoft.CognitiveServices.Speech.extension.kws.so",
-        Path::new(&out_path).join("libMicrosoft.CognitiveServices.Speech.extension.kws.so"),
-    )
-    .unwrap();
-    fs::copy(
-        "./SpeechSDK/lib/x64/libMicrosoft.CognitiveServices.Speech.extension.codec.so",
-        Path::new(&out_path).join("libMicrosoft.CognitiveServices.Speech.extension.codec.so"),
-    )
-    .unwrap();
-    println!("cargo:rustc-link-search=native={}", out_path.display());
-    println!("cargo:rustc-link-lib=dylib=Microsoft.CognitiveServices.Speech.core");
-    */
-
-    let mut renew = env::var("RENEW_SDK").map(|v| v == "1").unwrap_or(false);
-    let sdk_output_dir = out_path.join("sdk_output");
-    if !sdk_output_dir.exists() || fs::read_dir(&sdk_output_dir).unwrap().next().is_none() {
-        renew = true;
-        fs::create_dir_all(&sdk_output_dir).unwrap();
-    }
-
-    let sdk_tar_file = out_path.join(format!("SpeechSDK-Linux-{SPEECH_SDK_VERSION}.tar.gz"));
-    if !sdk_tar_file.exists() {
-        download_file(linux_sdk_url.as_str(), sdk_tar_file.to_str().unwrap());
-    }
-
-    if renew {
-        let args = [
-            "--strip",
-            "1",
-            "-xzf",
-            sdk_tar_file.to_str().unwrap(),
-            "-C",
-            sdk_output_dir.to_str().unwrap(),
-        ];
-        Command::new("tar").args(args).status().unwrap();
-    }
-
-    #[cfg(target_arch = "x86")]
-    let lib_path = sdk_output_dir.join("lib").join("x86");
-    #[cfg(target_arch = "x86_64")]
-    let lib_path = sdk_output_dir.join("lib").join("x64");
-    #[cfg(target_arch = "arm")]
-    let lib_path = sdk_output_dir.join("lib").join("arm32");
-    #[cfg(target_arch = "aarch64")]
-    let lib_path = sdk_output_dir.join("lib").join("arm64");
-
-    let mut inc_arg = String::from("-I");
-    inc_arg.push_str(
-        sdk_output_dir
-            .join("include")
-            .join("c_api")
-            .to_str()
-            .unwrap(),
-    );
-
-    println!("cargo:rustc-link-search=native={}", lib_path.display());
-    println!("cargo:rustc-link-lib=dylib=Microsoft.CognitiveServices.Speech.core");
-
-    let skip_bindgen = env::var("MS_COG_SVC_SPEECH_SKIP_BINDGEN")
-        .map(|v| v == "1")
-        .unwrap_or(false);
-
-    if skip_bindgen {
+    if env_var("DOCS_RS").is_some() {
+        // Skip linking and bindgen when building docs as docs.rs won't have the
+        // dependency present and can't download it.
         return;
     }
 
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let bindings_builder = bindgen::Builder::default()
-        // The input header we would like to generate bindings for.
-        .header("c_api/wrapper.h")
-        .clang_arg(inc_arg.as_str());
+    let sdk_dir = if let Some(sdk_dir) = env_var("MS_COG_SVC_SPEECH_SDK_DIR") {
+        // If the user has specified an SDK directory then use that and don't
+        // try and download another one.
+        PathBuf::from(sdk_dir)
+    } else {
+        let download_dir = {
+            let mut dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+            dir.push("sdk_output");
+            dir
+        };
+        // Don't bother re-downloading the SDK if it looks like it's already
+        // there, unless it's been explicitly requested.
+        if env_var("MS_COG_SVC_SPEECH_RENEW_SDK").is_some()
+            || !download_dir.exists()
+            || fs::read_dir(&download_dir).unwrap().next().is_none()
+        {
+            fs::create_dir_all(&download_dir).unwrap();
+            download_sdk(&download_dir);
+        }
+        // Point the SDK dir at the thing that a user is most likely to point at
+        // if they download it themselves.
+        match TargetOs::get() {
+            TargetOs::Linux => download_dir.join(format!("SpeechSDK-Linux-{}", SPEECH_SDK_VERSION)),
+            TargetOs::MacOS => download_dir.join("MicrosoftCognitiveServicesSpeech.xcframework"),
+            TargetOs::Windows => download_dir,
+        }
+    };
 
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    let link_params = link_params(&sdk_dir);
+    println!("cargo:rustc-link-search={}", link_params.search_dir);
+    println!("cargo:rustc-link-lib={}", link_params.lib_arg);
+
+    if env_var("MS_COG_SVC_SPEECH_SKIP_BINDGEN").is_some() {
+        return;
+    }
+    println!("cargo::rustc-cfg=bindgen");
+
+    let include_dir = match TargetOs::get() {
+        TargetOs::Linux | TargetOs::Windows => sdk_dir.join("include/c_api"),
+        TargetOs::MacOS => {
+            sdk_dir.join("macos-arm64_x86_64/MicrosoftCognitiveServicesSpeech.framework/Headers")
+        }
+    };
+
+    let bindings_builder = bindgen::Builder::default()
+        .header("c_api/wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .clang_arg(format!("-I{}", include_dir.to_str().unwrap()));
+
+    #[cfg(any(
+        all(target_os = "linux", any(target_arch = "arm", target_arch = "aarch64")),
+        target_os = "macos",
+    ))]
     let bindings_builder = bindings_builder
         // use gcc to find correct include path for stddef.h
         .clang_arg(
@@ -121,168 +81,135 @@ fn main() {
                 .unwrap(),
         );
 
-    // Finish the builder and generate the bindings.
-    let bindings = bindings_builder
-        .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
-
-    // Write the bindings to the src/ffi/bindings.rs file.
-    bindings
-        .write_to_file("src/ffi/bindings.rs")
-        .expect("Couldn't write bindings!");
-}
-
-#[cfg(any(
-    all(target_os = "macos", target_arch = "aarch64"),
-    all(target_os = "macos", target_arch = "arm"),
-    all(target_os = "macos", target_arch = "x86_64")
-))]
-fn main() {
-    let mac_sdk_url = format!("https://csspeechstorage.blob.core.windows.net/drop/{SPEECH_SDK_VERSION}/MicrosoftCognitiveServicesSpeech-MacOSXCFramework-{SPEECH_SDK_VERSION}.zip");
-
-    // Build scripts should not modify any files outside of the `OUT_DIR` directory,
-    // othersize `cargo publish` will fail.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    let mut renew = env::var("RENEW_SDK").map(|v| v == "1").unwrap_or(false);
-    let sdk_output_dir = out_path.join("sdk_output");
-    if !sdk_output_dir.exists() || fs::read_dir(&sdk_output_dir).unwrap().next().is_none() {
-        renew = true;
-        fs::create_dir_all(&sdk_output_dir).unwrap();
-    }
-
-    let sdk_zip_file = out_path.join(format!(
-        "MicrosoftCognitiveServicesSpeech-MacOSXCFramework-{SPEECH_SDK_VERSION}.zip"
-    ));
-    if !sdk_zip_file.exists() {
-        download_file(mac_sdk_url.as_str(), sdk_zip_file.to_str().unwrap());
-    }
-
-    if renew {
-        let args = [
-            "-o",                           // Overwrite files without prompting
-            sdk_zip_file.to_str().unwrap(), // The zip file
-            "-d",
-            sdk_output_dir.to_str().unwrap(), // The directory to extract to
-        ];
-        Command::new("unzip").args(args).status().unwrap();
-    }
-
-    println!("cargo:rustc-link-search=framework={}/MicrosoftCognitiveServicesSpeech.xcframework/macos-arm64_x86_64", sdk_output_dir.display());
-    println!("cargo:rustc-link-lib=framework=MicrosoftCognitiveServicesSpeech");
-
-    let inc_arg = format!("-I{}/MicrosoftCognitiveServicesSpeech.xcframework/macos-arm64_x86_64/MicrosoftCognitiveServicesSpeech.framework/Headers", sdk_output_dir.display());
-
-    let bindings_builder = bindgen::Builder::default()
-        .header("c_api/wrapper.h")
-        .clang_arg(inc_arg);
-
-    let bindings_builder = bindings_builder.clang_arg(
-        Command::new("gcc")
-            .arg("--print-file-name=include")
-            .output()
-            .map(|o| format!("-I{}", String::from_utf8_lossy(&o.stdout).trim()))
-            .unwrap(),
-    );
-
     let bindings = bindings_builder
         .generate()
         .expect("Unable to generate bindings");
 
+    let out_path = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
     bindings
-        .write_to_file("src/ffi/bindings.rs")
+        .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    if env_var("MS_COG_SVC_SPEECH_UPDATE_BINDINGS").is_some() {
+        bindings
+            .write_to_file("src/ffi/bindings.rs")
+            .expect("Unable to update bindings");
+    }
 }
 
-#[cfg(target_os = "windows")]
-fn main() {
-    use std::{fs::File, io::BufReader};
-    use zip::ZipArchive;
-
-    let nuget_package_url = format!("https://www.nuget.org/api/v2/package/Microsoft.CognitiveServices.Speech/{SPEECH_SDK_VERSION}");
-
-    // Build scripts should not modify any files outside of the `OUT_DIR` directory,
-    // othersize `cargo publish` will fail.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    let mut renew = env::var("RENEW_SDK").map(|v| v == "1").unwrap_or(false);
-    let sdk_output_dir = out_path.join("sdk_output");
-    if !sdk_output_dir.exists() {
-        renew = true;
-        fs::create_dir_all(&sdk_output_dir).unwrap();
+/// Download the SDK from the official Microsoft source into the given path,
+/// the file structure depends on the target OS.
+fn download_sdk(path: &Path) {
+    let zip_url = match TargetOs::get() {
+        TargetOs::Linux => {
+            let sdk_url = format!(
+                "https://csspeechstorage.blob.core.windows.net/drop/{SPEECH_SDK_VERSION}/SpeechSDK-Linux-{SPEECH_SDK_VERSION}.tar.gz");
+            let sdk = ureq::get(&sdk_url)
+                .call()
+                .expect("Failed to download Speech SDK");
+            let mut archive = tar::Archive::new(GzDecoder::new(sdk.into_reader()));
+            for entry in archive.entries().unwrap() {
+                entry.unwrap().unpack_in(path).unwrap();
+            }
+            return;
+        },
+        TargetOs::MacOS => format!("https://csspeechstorage.blob.core.windows.net/drop/{SPEECH_SDK_VERSION}/MicrosoftCognitiveServicesSpeech-MacOSXCFramework-{SPEECH_SDK_VERSION}.zip"),
+        TargetOs::Windows => format!("https://www.nuget.org/api/v2/package/Microsoft.CognitiveServices.Speech/{SPEECH_SDK_VERSION}"),
+    };
+    let mut sdk = ureq::get(&zip_url)
+        .call()
+        .expect("Failed to download Speech SDK")
+        .into_reader();
+    while let Some(mut zip_file) = zip::read::read_zipfile_from_stream(&mut sdk).unwrap() {
+        if zip_file.is_dir() {
+            fs::create_dir_all(path.join(zip_file.enclosed_name().unwrap())).unwrap();
+        } else {
+            let file_path = path.join(zip_file.enclosed_name().unwrap());
+            fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+            let mut file = fs::File::create(file_path).unwrap();
+            std::io::copy(&mut zip_file, &mut file).unwrap();
+        }
     }
+}
 
-    let sdk_zip_file = out_path.join(format!(
-        "microsoft.cognitiveservices.speech.{SPEECH_SDK_VERSION}.nupkg"
-    ));
-    if !sdk_zip_file.exists() {
-        download_file(nuget_package_url.as_str(), sdk_zip_file.to_str().unwrap());
-    }
+struct LinkParams {
+    lib_arg: String,
+    search_dir: String,
+}
 
-    if renew {
-        let reader = File::open(sdk_zip_file).unwrap();
-        let mut archive = ZipArchive::new(BufReader::new(reader)).unwrap();
-
-        for i in 0..archive.len() {
-            let mut file = archive.by_index(i).unwrap();
-            let outpath = sdk_output_dir.join(file.mangled_name());
-
-            if file.name().ends_with('/') {
-                std::fs::create_dir_all(&outpath).unwrap();
+/// Get the link parameters for the Speech SDK based on the target OS and architecture.
+fn link_params(sdk_dir: &Path) -> LinkParams {
+    match TargetOs::get() {
+        TargetOs::Linux => {
+            let mut lib_dir = sdk_dir.join("lib");
+            if cfg!(target_arch = "x86") {
+                lib_dir.push("x86")
+            } else if cfg!(target_arch = "x86_64") {
+                lib_dir.push("x64")
+            } else if cfg!(target_arch = "arm") {
+                lib_dir.push("arm32")
+            } else if cfg!(target_arch = "aarch64") {
+                lib_dir.push("arm64")
             } else {
-                if let Some(p) = outpath.parent() {
-                    if !p.exists() {
-                        std::fs::create_dir_all(p).unwrap();
-                    }
-                }
-                let mut outfile = std::fs::File::create(&outpath).unwrap();
-                std::io::copy(&mut file, &mut outfile).unwrap();
+                panic!("Unsupported target architecture; only x86, x86_64, arm, and aarch64 are supported on Linux.")
+            }
+            LinkParams {
+                lib_arg: "dylib=Microsoft.CognitiveServices.Speech.core".to_owned(),
+                search_dir: format!("native={}", lib_dir.to_str().unwrap()),
+            }
+        }
+        TargetOs::MacOS => LinkParams {
+            lib_arg: "framework=MicrosoftCognitiveServicesSpeech".to_owned(),
+            search_dir: format!(
+                "framework={}",
+                sdk_dir.join("macos-arm64_x86_64").to_str().unwrap()
+            ),
+        },
+        TargetOs::Windows => {
+            let mut lib_dir = sdk_dir.join("build/native");
+            if cfg!(target_arch = "x86") {
+                lib_dir.push("Win32")
+            } else if cfg!(target_arch = "x86_64") {
+                lib_dir.push("x64")
+            } else if cfg!(target_arch = "arm") {
+                lib_dir.push("ARM")
+            } else if cfg!(target_arch = "aarch64") {
+                lib_dir.push("ARM64")
+            } else {
+                panic!("Unsupported target architecture; only x86, x86_64, arm, and aarch64 are supported on Windows.")
+            }
+            lib_dir.push("Release");
+            LinkParams {
+                lib_arg: "dylib=Microsoft.CognitiveServices.Speech.core".to_owned(),
+                search_dir: format!("native={}", lib_dir.to_str().unwrap()),
             }
         }
     }
+}
 
-    let native = sdk_output_dir.join("build").join("native");
+/// Get an environment variable and register it with cargo so the build is rerun
+/// if it's changed.
+fn env_var(name: &str) -> Option<OsString> {
+    println!("cargo::rerun-if-env-changed={name}");
+    std::env::var_os(name)
+}
 
-    #[cfg(target_arch = "x86")]
-    let lib_path = native.join("Win32").join("Release");
-    #[cfg(target_arch = "x86_64")]
-    let lib_path = native.join("x64").join("Release");
-    #[cfg(target_arch = "arm")]
-    let lib_path = native.join("ARM").join("Release");
-    #[cfg(target_arch = "aarch64")]
-    let lib_path = native.join("ARM64").join("Release");
+enum TargetOs {
+    Linux,
+    MacOS,
+    Windows,
+}
 
-    let mut inc_arg = String::from("-I");
-    inc_arg.push_str(native.join("include").join("c_api").to_str().unwrap());
-
-    println!("cargo:rustc-link-search=native={}", lib_path.display());
-    println!("cargo:rustc-link-lib=dylib=Microsoft.CognitiveServices.Speech.core");
-
-    let skip_bindgen = env::var("MS_COG_SVC_SPEECH_SKIP_BINDGEN")
-        .map(|v| v == "1")
-        .unwrap_or(false);
-
-    if skip_bindgen {
-        return;
+impl TargetOs {
+    const fn get() -> TargetOs {
+        if cfg!(target_os = "linux") {
+            TargetOs::Linux
+        } else if cfg!(target_os = "macos") {
+            TargetOs::MacOS
+        } else if cfg!(target_os = "windows") {
+            TargetOs::Windows
+        } else {
+            panic!("Unsupported target OS; only linux, macos, and windows are supported.")
+        }
     }
-
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let bindings_builder = bindgen::Builder::default()
-        // The input header we would like to generate bindings for.
-        .header("c_api/wrapper.h")
-        .clang_arg(inc_arg.as_str());
-
-    // Finish the builder and generate the bindings.
-    let bindings = bindings_builder
-        .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
-
-    // Write the bindings to the src/ffi/bindings.rs file.
-    bindings
-        .write_to_file("src/ffi/bindings.rs")
-        .expect("Couldn't write bindings!");
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,6 +1,10 @@
 //! Package ffi contains bindings to underlying C API and thin abstraction for managing C handles.
 #![allow(warnings)]
 #![allow(unaligned_references)]
+
+#[cfg(bindgen)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+#[cfg(not(bindgen))]
 include!("ffi/bindings.rs");
 
 // manual entry as API v1.21.0 is using this types as #define so bindings.rs does not contains them


### PR DESCRIPTION
We have a security requirement to only source dependencies in a secure way, downloading from an arbitrary URL in the build.rs doesn't satisfy that, so I'm adding the ability to provide your own copy of the SDK.

This change ended up being relatively large so that I could be more sure that I'd made the same change for all 3 target OSs (hopefully this makes it more maintainable in the future). I only *need* to make it so that we aren't required to download but I ended up making these behavioural changes:
1. The automatic download is disabled if `MS_COG_SVC_SPEECH_SDK_DIR` is set.
   * I would actually prefer that you have to explicitly ask it to do the automatic download, as I'd like to prevent accidental downloads. I think this might even be acceptable as realistically anyone who distributes this needs to obtain the SDK library separately. What do you think?
   * I'm doing nothing to check that the version of the SDK at `MS_COG_SVC_SPEECH_SDK_DIR` is the correct version, I could do something like check the library against a hash (and warn if it's wrong) but I'm not sure whether that's a good idea.
1. I renamed the `RENEW_SDK` environment variable to `MS_COG_SVC_SPEECH_RENEW_SDK` and now it only needs to be set to something, not necessarily "1".
1. `MS_COG_SVC_SPEECH_SKIP_BINDGEN` now only needs to be set, not necessarily to "1".
1. bindgen now writes the bindings to `OUT_DIR` rather than src/ffi/bindings.rs (unless `MS_COG_SVC_SPEECH_UPDATE_BINDINGS` is set), and the ffi module will use that unless bindgen is skipped for any reason.
1. build.rs does nothing when being built by docs.rs so that https://docs.rs/cognitive-services-speech-sdk-rs starts working (as documented in https://docs.rs/about/builds#detecting-docsrs)

