### PR TITLE
Small improvements to word boundary events

### DIFF
--- a/src/speech/speech_synthesis_word_boundary_event.rs
+++ b/src/speech/speech_synthesis_word_boundary_event.rs
@@ -11,7 +11,7 @@ pub struct SpeechSynthesisWordBoundaryEvent {
     pub handle: SmartHandle<SPXEVENTHANDLE>,
     pub audio_offset: u64,
     pub duration_ms: u64,
-    pub text_offset: u32,
+    pub text_offset: Option<u32>,
     pub word_length: u32,
     pub boundary_type: SpeechSynthesisBoundaryType,
 }
@@ -35,6 +35,12 @@ impl SpeechSynthesisWordBoundaryEvent {
                 &mut boundary_type,
             );
             convert_err(ret, "SpeechSynthesisWordBoundaryEvent::from_handle error")?;
+
+            // The text_offset is set to -1 (u32::MAX) if the event's text
+            // doesn't exactly match the input SSML. For example, if the event's
+            // text is "cat's" and the input SSML contains "cat&apos;s". In this
+            // case, we should make the programmer aware and map to Option<u32>.
+            let text_offset = if text_offset == u32::MAX { None } else { Some(text_offset) };
 
             #[cfg(target_os = "windows")]
             let boundary_type = SpeechSynthesisBoundaryType::from_i32(boundary_type);


### PR DESCRIPTION
After digging into [this issue](https://github.com/jabber-tools/cognitive-services-speech-sdk-rs/issues/24) I found that text_offset is set to -1 (u32::MAX) when the text doesn't exactly match a substring in the SSML. This also means we can't reliably extract the text by character indexes, so call the C API to do that.