### PR TITLE
Fix a panic when getting the list of voices

### DIFF
--- a/src/audio/push_audio_input_stream.rs
+++ b/src/audio/push_audio_input_stream.rs
@@ -95,10 +95,15 @@ impl PushAudioInputStream {
 
     pub fn set_property_by_name(&mut self, name: String, value: String) -> Result<()> {
         unsafe {
-            let c_name = CString::new(name)?.as_ptr();
-            let c_value = CString::new(value)?.as_ptr();
-            let ret =
-                push_audio_input_stream_set_property_by_name(self.handle.inner(), c_name, c_value);
+            let c_name = CString::new(name)?;
+            let c_name_ptr = c_name.as_ptr();
+            let c_value = CString::new(value)?;
+            let c_value_ptr = c_value.as_ptr();
+            let ret = push_audio_input_stream_set_property_by_name(
+                self.handle.inner(),
+                c_name_ptr,
+                c_value_ptr,
+            );
             convert_err(ret, "PushAudioInputStream.set_property_by_name error")?;
             Ok(())
         }
@@ -106,11 +111,12 @@ impl PushAudioInputStream {
 
     pub fn set_property(&mut self, id: PropertyId, value: String) -> Result<()> {
         unsafe {
-            let c_value = CString::new(value)?.as_ptr();
+            let c_value = CString::new(value)?;
+            let c_value_ptr = c_value.as_ptr();
             let ret = push_audio_input_stream_set_property_by_id(
                 self.handle.inner(),
                 id.to_i32(),
-                c_value,
+                c_value_ptr,
             );
             convert_err(ret, "PushAudioInputStream.set_property error")?;
             Ok(())

--- a/src/common/property_collection.rs
+++ b/src/common/property_collection.rs
@@ -65,12 +65,13 @@ impl PropertyCollection {
         S: Into<Vec<u8>>,
     {
         unsafe {
-            let c_default_val = CString::new(default_val)?.as_ptr();
+            let c_default_val = CString::new(default_val)?;
+            let c_default_val_ptr = c_default_val.as_ptr();
             let ret = property_bag_get_string(
                 self.handle.inner(),
                 prop_id.to_i32(),
                 std::ptr::null(),
-                c_default_val,
+                c_default_val_ptr,
             );
             if ret == NULL_C_STR_PTR {
                 Ok("".to_owned())
@@ -99,9 +100,12 @@ impl PropertyCollection {
         S: Into<Vec<u8>>,
     {
         unsafe {
-            let c_name = CString::new(prop_name)?.as_ptr();
-            let c_default_val = CString::new(default_val)?.as_ptr();
-            let ret = property_bag_get_string(self.handle.inner(), -1, c_name, c_default_val);
+            let c_name = CString::new(prop_name)?;
+            let c_name_ptr = c_name.as_ptr();
+            let c_default_val = CString::new(default_val)?;
+            let c_default_val_ptr = c_default_val.as_ptr();
+            let ret =
+                property_bag_get_string(self.handle.inner(), -1, c_name_ptr, c_default_val_ptr);
             if ret == NULL_C_STR_PTR {
                 Ok("".to_owned())
             } else {

--- a/src/speech/speech_synthesis_result.rs
+++ b/src/speech/speech_synthesis_result.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for SpeechSynthesisResult {
         } else {
             &self.audio_data[..]
         };
-        f.debug_struct("SpeechRecognitionResult")
+        f.debug_struct("SpeechSynthesisResult")
             .field("result_id", &self.result_id)
             .field("reason", &self.reason)
             .field(

--- a/src/speech/synthesis_voices_result.rs
+++ b/src/speech/synthesis_voices_result.rs
@@ -59,7 +59,6 @@ impl SynthesisVoicesResult {
                 ret,
                 "SynthesisVoicesResult::from_handle(synthesis_voices_result_get_voice_num) error",
             )?;
-            voice_num -= 1;
             let mut voices = vec![];
             for idx in 0..voice_num {
                 let mut voice_info_handle: MaybeUninit<SPXRESULTHANDLE> = MaybeUninit::uninit();


### PR DESCRIPTION
We should not subtract 1 from voice_num since the range does not include the end value. This was causing the last voice not to be included in the list and we were also occasionally seeing the following panic:

```
Error { message: "SynthesisVoicesResult::from_handle(synthesis_voices_result_get_voice_info) error: vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)", caused_by: ApiError(3) }
```

I think this was caused by the Azure API returning 0 voices and then voice_num was underflowing, resulting in calling synthesis_voices_result_get_voice_info with an idx that is out of range (e.g. 4294967295). I'm not sure why Azure would return 0 voices from the API, though.