### PR TITLE
Simplify the cross platform code by implementing the From traits for enums.

### DIFF
--- a/src/audio/audio_stream_container_format.rs
+++ b/src/audio/audio_stream_container_format.rs
@@ -15,23 +15,14 @@ pub enum AudioStreamContainerFormat {
     Amrwb = 263,
 }
 
-impl AudioStreamContainerFormat {
-    /// Converts enum instance to respective u32 value.
-    pub fn to_u32(&self) -> u32 {
-        match self {
-            AudioStreamContainerFormat::OggOpus => 257,
-            AudioStreamContainerFormat::Mp3 => 258,
-            AudioStreamContainerFormat::Flac => 259,
-            AudioStreamContainerFormat::Alaw => 260,
-            AudioStreamContainerFormat::Mulaw => 261,
-            /// Currently not supported
-            AudioStreamContainerFormat::Amrnb => 262,
-            /// Currently not supported
-            AudioStreamContainerFormat::Amrwb => 263,
-        }
+impl From<AudioStreamContainerFormat> for u32 {
+    fn from(format: AudioStreamContainerFormat) -> Self {
+        format as u32
     }
+}
 
-    pub fn to_i32(&self) -> i32 {
-        self.to_u32() as i32
+impl From<AudioStreamContainerFormat> for i32 {
+    fn from(format: AudioStreamContainerFormat) -> Self {
+        format as i32
     }
 }

--- a/src/audio/audio_stream_format.rs
+++ b/src/audio/audio_stream_format.rs
@@ -74,13 +74,9 @@ impl AudioStreamFormat {
     ) -> Result<AudioStreamFormat> {
         unsafe {
             let mut handle: MaybeUninit<SPXAUDIOSTREAMFORMATHANDLE> = MaybeUninit::uninit();
-            #[cfg(not(target_os = "windows"))]
-            let compressed_format = compressed_format.to_u32();
-            #[cfg(target_os = "windows")]
-            let compressed_format = compressed_format.to_i32();
             let ret = audio_stream_format_create_from_compressed_format(
                 handle.as_mut_ptr(),
-                compressed_format,
+                compressed_format.into(),
             );
             convert_err(ret, "AudioStreamFormat::get_compressed_format error")?;
             AudioStreamFormat::from_handle(handle.assume_init())

--- a/src/common/cancellation_error_code.rs
+++ b/src/common/cancellation_error_code.rs
@@ -42,8 +42,16 @@ impl CancellationErrorCode {
             _ => CancellationErrorCode::RuntimeError,
         }
     }
+}
 
-    pub fn from_i32(code: i32) -> Self {
-        CancellationErrorCode::from_u32(code as u32)
+impl From<u32> for CancellationErrorCode {
+    fn from(value: u32) -> Self {
+        CancellationErrorCode::from_u32(value)
+    }
+}
+
+impl From<i32> for CancellationErrorCode {
+    fn from(value: i32) -> Self {
+        CancellationErrorCode::from_u32(value as u32)
     }
 }

--- a/src/common/cancellation_reason.rs
+++ b/src/common/cancellation_reason.rs
@@ -17,8 +17,16 @@ impl CancellationReason {
             _ => CancellationReason::CancelledByUser,
         }
     }
+}
 
-    pub fn from_i32(code: i32) -> Self {
-        CancellationReason::from_u32(code as u32)
+impl From<u32> for CancellationReason {
+    fn from(value: u32) -> Self {
+        CancellationReason::from_u32(value)
+    }
+}
+
+impl From<i32> for CancellationReason {
+    fn from(value: i32) -> Self {
+        CancellationReason::from_u32(value as u32)
     }
 }

--- a/src/common/profanity_option.rs
+++ b/src/common/profanity_option.rs
@@ -10,3 +10,15 @@ pub enum ProfanityOption {
     /// Raw profanity option
     Raw = 2,
 }
+
+impl From<ProfanityOption> for u32 {
+    fn from(option: ProfanityOption) -> Self {
+        option as u32
+    }
+}
+
+impl From<ProfanityOption> for i32 {
+    fn from(option: ProfanityOption) -> Self {
+        option as i32
+    }
+}

--- a/src/common/result_reason.rs
+++ b/src/common/result_reason.rs
@@ -66,8 +66,16 @@ impl ResultReason {
             _ => ResultReason::VoicesListRetrieved,
         }
     }
+}
 
-    pub fn from_i32(reason: i32) -> Self {
-        ResultReason::from_u32(reason as u32)
+impl From<u32> for ResultReason {
+    fn from(value: u32) -> Self {
+        ResultReason::from_u32(value)
+    }
+}
+
+impl From<i32> for ResultReason {
+    fn from(value: i32) -> Self {
+        ResultReason::from_u32(value as u32)
     }
 }

--- a/src/common/service_property_channel.rs
+++ b/src/common/service_property_channel.rs
@@ -4,3 +4,15 @@ pub enum ServicePropertyChannel {
     /// URIQueryParameter uses URI query parameter to pass property settings to service.
     URIQueryParameter = 0,
 }
+
+impl From<ServicePropertyChannel> for u32 {
+    fn from(channel: ServicePropertyChannel) -> Self {
+        channel as u32
+    }
+}
+
+impl From<ServicePropertyChannel> for i32 {
+    fn from(channel: ServicePropertyChannel) -> Self {
+        channel as i32
+    }
+}

--- a/src/common/speech_synthesis_boundary_type.rs
+++ b/src/common/speech_synthesis_boundary_type.rs
@@ -19,8 +19,16 @@ impl SpeechSynthesisBoundaryType {
             _ => SpeechSynthesisBoundaryType::SentenceBoundary,
         }
     }
+}
 
-    pub fn from_i32(value: i32) -> Self {
+impl From<u32> for SpeechSynthesisBoundaryType {
+    fn from(value: u32) -> Self {
+        SpeechSynthesisBoundaryType::from_u32(value)
+    }
+}
+
+impl From<i32> for SpeechSynthesisBoundaryType {
+    fn from(value: i32) -> Self {
         SpeechSynthesisBoundaryType::from_u32(value as u32)
     }
 }

--- a/src/common/stream_status.rs
+++ b/src/common/stream_status.rs
@@ -27,8 +27,16 @@ impl StreamStatus {
             _ => StreamStatus::StreamStatusCanceled,
         }
     }
+}
 
-    pub fn from_i32(status: i32) -> Self {
-        StreamStatus::from_u32(status as u32)
+impl From<u32> for StreamStatus {
+    fn from(value: u32) -> Self {
+        StreamStatus::from_u32(value)
+    }
+}
+
+impl From<i32> for StreamStatus {
+    fn from(value: i32) -> Self {
+        StreamStatus::from_u32(value as u32)
     }
 }

--- a/src/common/synthesis_voice_type.rs
+++ b/src/common/synthesis_voice_type.rs
@@ -23,8 +23,16 @@ impl SynthesisVoiceType {
             _ => SynthesisVoiceType::OfflineStandard,
         }
     }
+}
 
-    pub fn from_i32(reason: i32) -> Self {
-        SynthesisVoiceType::from_u32(reason as u32)
+impl From<u32> for SynthesisVoiceType {
+    fn from(value: u32) -> Self {
+        SynthesisVoiceType::from_u32(value)
+    }
+}
+
+impl From<i32> for SynthesisVoiceType {
+    fn from(value: i32) -> Self {
+        SynthesisVoiceType::from_u32(value as u32)
     }
 }

--- a/src/speech/audio_data_stream.rs
+++ b/src/speech/audio_data_stream.rs
@@ -70,10 +70,7 @@ impl AudioDataStream {
             let ret = audio_data_stream_get_status(self.handle.inner(), &mut status);
             convert_err(ret, "AudioDataStream.get_status error")?;
 
-            #[cfg(target_os = "windows")]
-            return Ok(StreamStatus::from_i32(status));
-            #[cfg(not(target_os = "windows"))]
-            return Ok(StreamStatus::from_u32(status));
+            Ok(status.into())
         }
     }
 

--- a/src/speech/cancellation_details.rs
+++ b/src/speech/cancellation_details.rs
@@ -41,23 +41,11 @@ impl CancellationDetails {
                 .properties
                 .get_property(PropertyId::CancellationDetailsReasonDetailedText, "")?;
 
-            #[cfg(target_os = "windows")]
-            {
-                Ok(CancellationDetails {
-                    reason: CancellationReason::from_i32(reason),
-                    error_code: CancellationErrorCode::from_i32(error_code),
-                    error_details,
-                })
-            }
-
-            #[cfg(not(target_os = "windows"))]
-            {
-                Ok(CancellationDetails {
-                    reason: CancellationReason::from_u32(reason),
-                    error_code: CancellationErrorCode::from_u32(error_code),
-                    error_details,
-                })
-            }
+            Ok(CancellationDetails {
+                reason: reason.into(),
+                error_code: error_code.into(),
+                error_details,
+            })
         }
     }
 }

--- a/src/speech/speech_config.rs
+++ b/src/speech/speech_config.rs
@@ -236,16 +236,11 @@ impl SpeechConfig {
             let c_name = CString::new(name)?;
             let c_value = CString::new(value)?;
 
-            #[cfg(target_os = "windows")]
-            let channel = channel as i32;
-            #[cfg(not(target_os = "windows"))]
-            let channel = channel as u32;
-
             let ret = speech_config_set_service_property(
                 self.handle.inner(),
                 c_name.as_ptr(),
                 c_value.as_ptr(),
-                channel,
+                channel.into(),
             );
             convert_err(ret, "SpeechConfig.set_service_property error")?;
             Ok(())
@@ -253,13 +248,8 @@ impl SpeechConfig {
     }
 
     pub fn set_profanity_option(&mut self, profanity_option: ProfanityOption) -> Result<()> {
-        #[cfg(target_os = "windows")]
-        let profanity_option = profanity_option as i32;
-        #[cfg(not(target_os = "windows"))]
-        let profanity_option = profanity_option as u32;
-
         unsafe {
-            let ret = speech_config_set_profanity(self.handle.inner(), profanity_option);
+            let ret = speech_config_set_profanity(self.handle.inner(), profanity_option.into());
             convert_err(ret, "SpeechConfig.set_profanity_option error")?;
             Ok(())
         }

--- a/src/speech/speech_recognition_canceled_event.rs
+++ b/src/speech/speech_recognition_canceled_event.rs
@@ -48,24 +48,12 @@ impl SpeechRecognitionCanceledEvent {
                 error_details = error_details_res.unwrap();
             }
 
-            #[cfg(target_os = "windows")]
-            {
-                Ok(SpeechRecognitionCanceledEvent {
-                    base,
-                    reason: CancellationReason::from_i32(reason),
-                    error_code: CancellationErrorCode::from_i32(error_code),
-                    error_details,
-                })
-            }
-            #[cfg(not(target_os = "windows"))]
-            {
-                Ok(SpeechRecognitionCanceledEvent {
-                    base,
-                    reason: CancellationReason::from_u32(reason),
-                    error_code: CancellationErrorCode::from_u32(error_code),
-                    error_details,
-                })
-            }
+            Ok(SpeechRecognitionCanceledEvent {
+                base,
+                reason: reason.into(),
+                error_code: error_code.into(),
+                error_details,
+            })
         }
     }
 }

--- a/src/speech/speech_recognition_result.rs
+++ b/src/speech/speech_recognition_result.rs
@@ -82,11 +82,6 @@ impl SpeechRecognitionResult {
             )?;
             let properties = PropertyCollection::from_handle(properties_handle.assume_init());
 
-            #[cfg(target_os = "windows")]
-            let reason = ResultReason::from_i32(reason);
-            #[cfg(not(target_os = "windows"))]
-            let reason = ResultReason::from_u32(reason);
-
             Ok(SpeechRecognitionResult {
                 handle: SmartHandle::create(
                     "SpeechRecognitionResult",
@@ -94,7 +89,7 @@ impl SpeechRecognitionResult {
                     recognizer_result_handle_release,
                 ),
                 result_id,
-                reason,
+                reason: reason.into(),
                 text: result_text,
                 duration: (duration).to_string(),
                 offset: (offset).to_string(),

--- a/src/speech/speech_synthesis_result.rs
+++ b/src/speech/speech_synthesis_result.rs
@@ -99,11 +99,6 @@ impl SpeechSynthesisResult {
             )?;
             let properties = PropertyCollection::from_handle(properties_handle.assume_init());
 
-            #[cfg(target_os = "windows")]
-            let reason = ResultReason::from_i32(reason);
-            #[cfg(not(target_os = "windows"))]
-            let reason = ResultReason::from_u32(reason);
-
             let speech_synthesis_result = SpeechSynthesisResult {
                 handle: SmartHandle::create(
                     "SpeechSynthesisResult",
@@ -111,7 +106,7 @@ impl SpeechSynthesisResult {
                     synthesizer_result_handle_release,
                 ),
                 result_id,
-                reason,
+                reason: reason.into(),
                 audio_data: slice_buffer.to_vec(),
                 audio_duration_ms: audio_duration,
                 properties,

--- a/src/speech/speech_synthesis_word_boundary_event.rs
+++ b/src/speech/speech_synthesis_word_boundary_event.rs
@@ -39,11 +39,6 @@ impl SpeechSynthesisWordBoundaryEvent {
             );
             convert_err(ret, "SpeechSynthesisWordBoundaryEvent::from_handle error")?;
 
-            #[cfg(target_os = "windows")]
-            let boundary_type = SpeechSynthesisBoundaryType::from_i32(boundary_type);
-            #[cfg(not(target_os = "windows"))]
-            let boundary_type = SpeechSynthesisBoundaryType::from_u32(boundary_type);
-
             let c_text = synthesizer_event_get_text(handle);
             let text = CStr::from_ptr(c_text).to_str()?.to_owned();
             let ret = property_bag_free_string(c_text);
@@ -62,7 +57,7 @@ impl SpeechSynthesisWordBoundaryEvent {
                 duration_ms,
                 text_offset,
                 word_length,
-                boundary_type,
+                boundary_type: boundary_type.into(),
                 text,
             })
         }

--- a/src/speech/synthesis_voices_result.rs
+++ b/src/speech/synthesis_voices_result.rs
@@ -76,11 +76,6 @@ impl SynthesisVoicesResult {
                 voices.push(voice_info);
             }
 
-            #[cfg(target_os = "windows")]
-            let reason = ResultReason::from_i32(reason);
-            #[cfg(not(target_os = "windows"))]
-            let reason = ResultReason::from_u32(reason);
-
             Ok(SynthesisVoicesResult {
                 handle: SmartHandle::create(
                     "SynthesisVoicesResult",
@@ -89,7 +84,7 @@ impl SynthesisVoicesResult {
                 ),
                 voices,
                 result_id,
-                reason,
+                reason: reason.into(),
                 error_details,
                 properties,
             })

--- a/src/speech/voice_info.rs
+++ b/src/speech/voice_info.rs
@@ -62,18 +62,13 @@ impl VoiceInfo {
                 "VoiceInfo::from_handle(voice_info_get_property_bag) error",
             )?;
 
-            #[cfg(target_os = "windows")]
-            let voice_type = SynthesisVoiceType::from_i32(voice_type);
-            #[cfg(not(target_os = "windows"))]
-            let voice_type = SynthesisVoiceType::from_u32(voice_type);
-
             Ok(VoiceInfo {
                 handle: SmartHandle::create("VoiceInfo", handle, voice_info_handle_release),
                 name: voice_name,
                 locale,
                 short_name,
                 local_name,
-                voice_type,
+                voice_type: voice_type.into(),
                 style_list,
                 voice_path,
                 properties: PropertyCollection::from_handle(prop_bag_handle.assume_init()),


### PR DESCRIPTION
This pull request focuses on refactoring the conversion logic for various enums to streamline the code and improve maintainability. 

The changes primarily involve replacing custom conversion methods with implementations of the `From` trait for `u32` and `i32` types. 