### PR TITLE
Add phrase list support for speech recognizer

### DIFF
--- a/src/speech.rs
+++ b/src/speech.rs
@@ -4,6 +4,7 @@ mod auto_detect_source_language_config;
 mod cancellation_details;
 mod embedded_speech_config;
 mod keyword_recognition_model;
+mod phrase_list_grammar;
 mod recognition_event;
 mod session_event;
 mod source_language_config;
@@ -28,6 +29,7 @@ pub use self::auto_detect_source_language_config::AutoDetectSourceLanguageConfig
 pub use self::cancellation_details::CancellationDetails;
 pub use self::embedded_speech_config::EmbeddedSpeechConfig;
 pub use self::keyword_recognition_model::KeywordRecognitionModel;
+pub use self::phrase_list_grammar::PhraseListGrammar;
 pub use self::recognition_event::RecognitionEvent;
 pub use self::session_event::SessionEvent;
 pub use self::source_language_config::SourceLanguageConfig;

--- a/src/speech.rs
+++ b/src/speech.rs
@@ -3,6 +3,7 @@ mod audio_data_stream;
 mod auto_detect_source_language_config;
 mod cancellation_details;
 mod embedded_speech_config;
+mod grammar_phrase;
 mod keyword_recognition_model;
 mod phrase_list_grammar;
 mod recognition_event;

--- a/src/speech/grammar_phrase.rs
+++ b/src/speech/grammar_phrase.rs
@@ -1,0 +1,37 @@
+use std::{ffi::CString, mem::MaybeUninit};
+
+use crate::{
+    error::{convert_err, Result},
+    ffi::{
+        grammar_phrase_create_from_text, grammar_phrase_handle_release, SmartHandle,
+        SPXPHRASEHANDLE,
+    },
+};
+
+/// Represents base class grammar for customizing speech recognition. \
+/// Added in version 1.5.0.
+#[derive(Debug)]
+pub(crate) struct GrammarPhrase {
+    pub handle: SmartHandle<SPXPHRASEHANDLE>,
+}
+
+impl GrammarPhrase {
+    /// Creates a grammar phrase using the specified phrase text.
+    /// # Arguments
+    /// * `text` - The text representing a phrase that may be spoken by the user.
+    pub(crate) fn from_text(text: impl AsRef<str>) -> Result<GrammarPhrase> {
+        unsafe {
+            let mut handle: MaybeUninit<SPXPHRASEHANDLE> = MaybeUninit::uninit();
+            let c_text = CString::new(text.as_ref())?;
+            let ret = grammar_phrase_create_from_text(handle.as_mut_ptr(), c_text.as_ptr());
+            convert_err(ret, "GrammarPhrase::grammar_phrase_from_text error")?;
+            Ok(GrammarPhrase {
+                handle: SmartHandle::create(
+                    "GrammarPhrase",
+                    handle.assume_init(),
+                    grammar_phrase_handle_release,
+                ),
+            })
+        }
+    }
+}

--- a/src/speech/phrase_list_grammar.rs
+++ b/src/speech/phrase_list_grammar.rs
@@ -65,14 +65,14 @@ struct GrammarPhrase {
 
 impl GrammarPhrase {
     /// Creates a grammar phrase using the specified phrase text.
-    // # Arguments
+    /// # Arguments
     /// * `text` - The text representing a phrase that may be spoken by the user.
     fn from_text(text: impl AsRef<str>) -> Result<GrammarPhrase> {
         unsafe {
             let mut handle: MaybeUninit<SPXPHRASEHANDLE> = MaybeUninit::uninit();
             let c_text = CString::new(text.as_ref())?;
             let ret = grammar_phrase_create_from_text(handle.as_mut_ptr(), c_text.as_ptr());
-            convert_err(ret, "GrammarPhrase::grammar_pharse_from_text error")?;
+            convert_err(ret, "GrammarPhrase::grammar_phrase_from_text error")?;
             Ok(GrammarPhrase {
                 handle: SmartHandle::create(
                     "GrammarPhrase",

--- a/src/speech/phrase_list_grammar.rs
+++ b/src/speech/phrase_list_grammar.rs
@@ -3,10 +3,10 @@ use std::mem::MaybeUninit;
 
 use crate::error::{convert_err, Result};
 use crate::ffi::{
-    grammar_handle_release, grammar_phrase_create_from_text, grammar_phrase_handle_release,
-    phrase_list_grammar_add_phrase, phrase_list_grammar_clear,
-    phrase_list_grammar_from_recognizer_by_name, SmartHandle, SPXGRAMMARHANDLE, SPXPHRASEHANDLE,
+    grammar_handle_release, phrase_list_grammar_add_phrase, phrase_list_grammar_clear,
+    phrase_list_grammar_from_recognizer_by_name, SmartHandle, SPXGRAMMARHANDLE,
 };
+use crate::speech::grammar_phrase::GrammarPhrase;
 use crate::speech::SpeechRecognizer;
 
 /// Represents a phrase list grammar for dynamic grammar scenarios. \
@@ -53,33 +53,5 @@ impl PhraseListGrammar {
         let ret = unsafe { phrase_list_grammar_clear(self.handle.inner()) };
         convert_err(ret, "PhraseListGrammar::clear error")?;
         Ok(())
-    }
-}
-
-/// Represents base class grammar for customizing speech recognition. \
-/// Added in version 1.5.0.
-#[derive(Debug)]
-struct GrammarPhrase {
-    handle: SmartHandle<SPXPHRASEHANDLE>,
-}
-
-impl GrammarPhrase {
-    /// Creates a grammar phrase using the specified phrase text.
-    /// # Arguments
-    /// * `text` - The text representing a phrase that may be spoken by the user.
-    fn from_text(text: impl AsRef<str>) -> Result<GrammarPhrase> {
-        unsafe {
-            let mut handle: MaybeUninit<SPXPHRASEHANDLE> = MaybeUninit::uninit();
-            let c_text = CString::new(text.as_ref())?;
-            let ret = grammar_phrase_create_from_text(handle.as_mut_ptr(), c_text.as_ptr());
-            convert_err(ret, "GrammarPhrase::grammar_phrase_from_text error")?;
-            Ok(GrammarPhrase {
-                handle: SmartHandle::create(
-                    "GrammarPhrase",
-                    handle.assume_init(),
-                    grammar_phrase_handle_release,
-                ),
-            })
-        }
     }
 }

--- a/src/speech/phrase_list_grammar.rs
+++ b/src/speech/phrase_list_grammar.rs
@@ -1,0 +1,85 @@
+use std::ffi::CString;
+use std::mem::MaybeUninit;
+
+use crate::error::{convert_err, Result};
+use crate::ffi::{
+    grammar_handle_release, grammar_phrase_create_from_text, grammar_phrase_handle_release,
+    phrase_list_grammar_add_phrase, phrase_list_grammar_clear,
+    phrase_list_grammar_from_recognizer_by_name, SmartHandle, SPXGRAMMARHANDLE, SPXPHRASEHANDLE,
+};
+use crate::speech::SpeechRecognizer;
+
+/// Represents a phrase list grammar for dynamic grammar scenarios. \
+/// Added in version 1.5.0.
+#[derive(Debug)]
+pub struct PhraseListGrammar {
+    handle: SmartHandle<SPXGRAMMARHANDLE>,
+}
+
+impl PhraseListGrammar {
+    /// Creates a phrase list grammar for the specified recognizer.
+    pub fn from_recognizer(recognizer: &SpeechRecognizer) -> Result<PhraseListGrammar> {
+        unsafe {
+            let c_name = CString::new("")?;
+            let mut handle: MaybeUninit<SPXGRAMMARHANDLE> = MaybeUninit::uninit();
+            let ret = phrase_list_grammar_from_recognizer_by_name(
+                handle.as_mut_ptr(),
+                recognizer.handle.inner(),
+                c_name.as_ptr(),
+            );
+            convert_err(ret, "PhraseListGrammar::from_recognizer error")?;
+            Ok(PhraseListGrammar {
+                handle: SmartHandle::create(
+                    "PhraseListGrammar",
+                    handle.assume_init(),
+                    grammar_handle_release,
+                ),
+            })
+        }
+    }
+
+    /// AddPhrase adds a simple phrase that may be spoken by the user.
+    pub fn add_phrase(&self, text: impl AsRef<str>) -> Result<()> {
+        let grammar_phrase = GrammarPhrase::from_text(text)?;
+        let ret: usize = unsafe {
+            phrase_list_grammar_add_phrase(self.handle.inner(), grammar_phrase.handle.inner())
+        };
+        convert_err(ret, "PhraseListGrammar::add_phrase error")?;
+        Ok(())
+    }
+
+    /// Clears all phrases from the phrase list grammar.
+    pub fn clear(&self) -> Result<()> {
+        let ret = unsafe { phrase_list_grammar_clear(self.handle.inner()) };
+        convert_err(ret, "PhraseListGrammar::clear error")?;
+        Ok(())
+    }
+}
+
+/// Represents base class grammar for customizing speech recognition. \
+/// Added in version 1.5.0.
+#[derive(Debug)]
+struct GrammarPhrase {
+    handle: SmartHandle<SPXPHRASEHANDLE>,
+}
+
+impl GrammarPhrase {
+    /// Creates a grammar phrase using the specified phrase text.
+    // # Arguments
+    /// * `text` - The text representing a phrase that may be spoken by the user.
+    fn from_text(text: impl AsRef<str>) -> Result<GrammarPhrase> {
+        unsafe {
+            let mut handle: MaybeUninit<SPXPHRASEHANDLE> = MaybeUninit::uninit();
+            let c_text = CString::new(text.as_ref())?;
+            let ret = grammar_phrase_create_from_text(handle.as_mut_ptr(), c_text.as_ptr());
+            convert_err(ret, "GrammarPhrase::grammar_pharse_from_text error")?;
+            Ok(GrammarPhrase {
+                handle: SmartHandle::create(
+                    "GrammarPhrase",
+                    handle.assume_init(),
+                    grammar_phrase_handle_release,
+                ),
+            })
+        }
+    }
+}

--- a/src/speech/speech_recognizer.rs
+++ b/src/speech/speech_recognizer.rs
@@ -32,7 +32,7 @@ use std::os::raw::c_void;
 
 /// SpeechRecognizer struct holds functionality for speech-to-text recognition.
 pub struct SpeechRecognizer {
-    handle: SmartHandle<SPXRECOHANDLE>,
+    pub(crate) handle: SmartHandle<SPXRECOHANDLE>,
     properties: PropertyCollection,
     handle_async_start_continuous: Option<SmartHandle<SPXASYNCHANDLE>>,
     handle_async_stop_continuous: Option<SmartHandle<SPXASYNCHANDLE>>,


### PR DESCRIPTION
This pull request introduces support for `phrase list` in the speech recognizer module.

The main changes include the addition of the `PhraseListGrammar` type, its integration into the public API, and a new integration test to verify phrase list functionality.

See the doc here: [Improve recognition accuracy with phrase list](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/improve-accuracy-phrase-list?tabs=terminal&pivots=programming-language-cpp)

> A phrase list is a list of words or phrases provided ahead of time to help improve their recognition. Adding a phrase to a phrase list increases its importance, thus making it more likely to be recognized.

Also see the go library's PR here: https://github.com/microsoft/cognitive-services-speech-sdk-go/pull/64