### PR TITLE
Fix segmentation fault in callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,6 @@ dependencies = [
  "env_logger",
  "log",
  "rodio",
- "rust-embed",
  "tokio",
  "zip",
 ]
@@ -1129,40 +1128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fbc0ee50fcb99af7cebb442e5df7b5b45e9460ffa3f8f549cd26b862bec49d"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf418c9a2e3f6663ca38b8a7134cc2c2167c9d69688860e8961e3faa731702e"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d55b95147fe01265d06b3955db798bdaed52e60e2211c41137701b3aba8e21"
-dependencies = [
- "sha2",
- "walkdir",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,17 +1198,6 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,7 @@ description = "Rust bindings for Microsoft Speech SDK."
 license = "MIT OR Apache-2.0"
 keywords = ["speech", "microsoft", "cognitive", "recognition", "synthesizing"]
 categories = ["multimedia", "multimedia::audio", "text-processing"]
-exclude = [
-    "examples/*"
-]
+exclude = ["examples/*"]
 repository = "https://github.com/jabber-tools/cognitive-services-speech-sdk-rs/"
 #documentation = "https://jabber-tools.github.io/cognitive_services_speech_sdk_rs/doc/1.0.0/cognitive_services_speech_sdk_rs/index.html"
 documentation = "https://docs.rs/cognitive-services-speech-sdk-rs"
@@ -19,12 +17,11 @@ documentation = "https://docs.rs/cognitive-services-speech-sdk-rs"
 [dependencies]
 log = "0.4"
 env_logger = "0.11.8"
-tokio = {version = "1.44.2", features = ["full"]} 
+tokio = { version = "1.44.2", features = ["full"] }
 
 [build-dependencies]
 bindgen = "0.69.4"
 zip = "2.6.1"
 
 [dev-dependencies]
-rust-embed = "8.4.0"
 rodio = "0.20.1"

--- a/src/audio/pull_audio_input_stream.rs
+++ b/src/audio/pull_audio_input_stream.rs
@@ -159,8 +159,6 @@ impl PullAudioInputStream {
         let callback_bag = &mut *(pvContext as *mut CallbackBag);
         if let Some(callbacks) = &mut callback_bag.callbacks {
             callbacks.close();
-        } else {
-            error!("PullAudioInputStream::cb_close callbacks not defined");
         }
     }
 
@@ -210,8 +208,6 @@ impl PullAudioInputStream {
                     );
                 }
             }
-        } else {
-            error!("PullAudioInputStream::cb_get_property callbacks not defined");
         }
     }
 }

--- a/src/audio/push_audio_output_stream.rs
+++ b/src/audio/push_audio_output_stream.rs
@@ -37,7 +37,7 @@ struct CallbackBag {
 /// Speech Synthetizer's caller is passivelly receiving already synthetized audio data via registered *write* callback.
 pub struct PushAudioOutputStream {
     pub handle: SmartHandle<SPXAUDIOSTREAMHANDLE>,
-    callbacks: Box<CallbackBag>,
+    callback_bag: Box<CallbackBag>,
 }
 
 impl fmt::Debug for PushAudioOutputStream {
@@ -60,7 +60,7 @@ impl PushAudioOutputStream {
     pub unsafe fn from_handle(handle: SPXAUDIOSTREAMHANDLE) -> Result<Self> {
         Ok(PushAudioOutputStream {
             handle: SmartHandle::create("PushAudioOutputStream", handle, audio_stream_release),
-            callbacks: Box::new(CallbackBag { callbacks: None }),
+            callback_bag: Box::new(CallbackBag { callbacks: None }),
         })
     }
 
@@ -78,11 +78,11 @@ impl PushAudioOutputStream {
         &mut self,
         callbacks: Box<dyn PushAudioOutputStreamCallbacks>,
     ) -> Result<()> {
-        self.callbacks.callbacks = Some(callbacks);
+        self.callback_bag.callbacks = Some(callbacks);
         unsafe {
             let ret = push_audio_output_stream_set_callbacks(
                 self.handle.inner(),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
                 Some(Self::cb_write),
                 Some(Self::cb_close),
             );

--- a/src/audio/push_audio_output_stream.rs
+++ b/src/audio/push_audio_output_stream.rs
@@ -120,8 +120,6 @@ impl PushAudioOutputStream {
         let callback_bag = &mut *(pvContext as *mut CallbackBag);
         if let Some(callbacks) = &mut callback_bag.callbacks {
             callbacks.close();
-        } else {
-            error!("PushAudioOutputStream::cb_close callbacks not defined");
         }
     }
 }

--- a/src/speech/speech_recognizer.rs
+++ b/src/speech/speech_recognizer.rs
@@ -52,7 +52,7 @@ pub struct SpeechRecognizer {
     handle_async_stop_continuous: Option<SmartHandle<SPXASYNCHANDLE>>,
     handle_async_start_keyword: Option<SmartHandle<SPXASYNCHANDLE>>,
     handle_async_stop_keyword: Option<SmartHandle<SPXASYNCHANDLE>>,
-    callbacks: Box<CallbackBag>,
+    callback_bag: Box<CallbackBag>,
 }
 
 impl fmt::Debug for SpeechRecognizer {
@@ -85,7 +85,7 @@ impl SpeechRecognizer {
                 // Here we return a boxed instance of the CallbackBag,
                 // ensure that the pointer we provide to the C library
                 // points to a stable, heap-allocated location that holds the callbacks.
-                callbacks: Box::new(CallbackBag {
+                callback_bag: Box::new(CallbackBag {
                     session_started_cb: None,
                     session_stopped_cb: None,
                     speech_start_detected_cb: None,
@@ -177,12 +177,12 @@ impl SpeechRecognizer {
     where
         F: Fn(SessionEvent) + 'static + Send,
     {
-        self.callbacks.session_started_cb = Some(Box::new(f));
+        self.callback_bag.session_started_cb = Some(Box::new(f));
         unsafe {
             let ret = recognizer_session_started_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_session_started),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_session_started_cb error")?;
             Ok(())
@@ -193,12 +193,12 @@ impl SpeechRecognizer {
     where
         F: Fn(SessionEvent) + 'static + Send,
     {
-        self.callbacks.session_stopped_cb = Some(Box::new(f));
+        self.callback_bag.session_stopped_cb = Some(Box::new(f));
         unsafe {
             let ret = recognizer_session_stopped_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_session_stopped),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_session_stopped_cb error")?;
             Ok(())
@@ -209,12 +209,12 @@ impl SpeechRecognizer {
     where
         F: Fn(RecognitionEvent) + 'static + Send,
     {
-        self.callbacks.speech_start_detected_cb = Some(Box::new(f));
+        self.callback_bag.speech_start_detected_cb = Some(Box::new(f));
         unsafe {
             let ret = recognizer_speech_start_detected_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_speech_start_detected),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_speech_start_detected_cb error")?;
             Ok(())
@@ -225,12 +225,12 @@ impl SpeechRecognizer {
     where
         F: Fn(RecognitionEvent) + 'static + Send,
     {
-        self.callbacks.speech_end_detected_cb = Some(Box::new(f));
+        self.callback_bag.speech_end_detected_cb = Some(Box::new(f));
         unsafe {
             let ret = recognizer_speech_end_detected_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_speech_end_detected),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_speech_end_detected_cb error")?;
             Ok(())
@@ -244,12 +244,12 @@ impl SpeechRecognizer {
     where
         F: Fn(SpeechRecognitionCanceledEvent) + 'static + Send,
     {
-        self.callbacks.canceled_cb = Some(Box::new(f));
+        self.callback_bag.canceled_cb = Some(Box::new(f));
         unsafe {
             let ret = recognizer_canceled_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_canceled),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_canceled_cb error")?;
             Ok(())
@@ -260,13 +260,13 @@ impl SpeechRecognizer {
     where
         F: Fn(SpeechRecognitionEvent) + 'static + Send,
     {
-        self.callbacks.recognizing_cb = Some(Box::new(f));
+        self.callback_bag.recognizing_cb = Some(Box::new(f));
         unsafe {
             trace!("calling recognizer_recognizing_set_callback");
             let ret = recognizer_recognizing_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_recognizing),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_recognizing_cb error")?;
             trace!("called recognizer_recognizing_set_callback");
@@ -278,13 +278,13 @@ impl SpeechRecognizer {
     where
         F: Fn(SpeechRecognitionEvent) + 'static + Send,
     {
-        self.callbacks.recognized_cb = Some(Box::new(f));
+        self.callback_bag.recognized_cb = Some(Box::new(f));
         unsafe {
             trace!("calling recognizer_recognized_set_callback");
             let ret = recognizer_recognized_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_recognized),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechRecognizer.set_recognized_cb error")?;
             trace!("called recognizer_recognized_set_callback");

--- a/src/speech/speech_synthesizer.rs
+++ b/src/speech/speech_synthesizer.rs
@@ -25,10 +25,11 @@ use std::fmt;
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 
-/// SpeechSynthesizer struct holds functionality for text-to-speech synthesis.
-pub struct SpeechSynthesizer {
-    handle: SmartHandle<SPXSYNTHHANDLE>,
-    properties: PropertyCollection,
+/// A separate internal struct to hold all the callback closures for the speech synthesizer events.
+/// By creating a separate struct, and then boxing this struct inside our SpeechSynthesizer,
+/// we can ensure the SpeechSynthesizer itself can be moved freely by end users,
+/// and the callbacks will remain at a fixed memory address on the heap.
+struct CallbackBag {
     synthesizer_started_cb: Option<Box<dyn Fn(SpeechSynthesisEvent) + Send>>,
     synthesizer_synthesizing_cb: Option<Box<dyn Fn(SpeechSynthesisEvent) + Send>>,
     synthesizer_completed_cb: Option<Box<dyn Fn(SpeechSynthesisEvent) + Send>>,
@@ -36,6 +37,13 @@ pub struct SpeechSynthesizer {
     synthesizer_word_boundary_cb: Option<Box<dyn Fn(SpeechSynthesisWordBoundaryEvent) + Send>>,
     synthesizer_viseme_cb: Option<Box<dyn Fn(SpeechSynthesisVisemeEvent) + Send>>,
     synthesizer_bookmark_cb: Option<Box<dyn Fn(SpeechSynthesisBookmarkEvent) + Send>>,
+}
+
+/// SpeechSynthesizer struct holds functionality for text-to-speech synthesis.
+pub struct SpeechSynthesizer {
+    handle: SmartHandle<SPXSYNTHHANDLE>,
+    properties: PropertyCollection,
+    callbacks: Box<CallbackBag>,
 }
 
 // to allow to move synthetizer to tokio::spawn
@@ -71,13 +79,18 @@ impl SpeechSynthesizer {
                     synthesizer_handle_release,
                 ),
                 properties: property_bag,
-                synthesizer_started_cb: None,
-                synthesizer_synthesizing_cb: None,
-                synthesizer_completed_cb: None,
-                synthesizer_canceled_cb: None,
-                synthesizer_word_boundary_cb: None,
-                synthesizer_viseme_cb: None,
-                synthesizer_bookmark_cb: None,
+                // Here we return a boxed instance of the CallbackBag,
+                // ensure that the pointer we provide to the C library
+                // points to a stable, heap-allocated location that holds the callbacks.
+                callbacks: Box::new(CallbackBag {
+                    synthesizer_started_cb: None,
+                    synthesizer_synthesizing_cb: None,
+                    synthesizer_completed_cb: None,
+                    synthesizer_canceled_cb: None,
+                    synthesizer_word_boundary_cb: None,
+                    synthesizer_viseme_cb: None,
+                    synthesizer_bookmark_cb: None,
+                }),
             })
         }
     }
@@ -271,12 +284,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.synthesizer_started_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_started_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_started_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_started),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_started_cb error")?;
             Ok(())
@@ -287,12 +300,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.synthesizer_synthesizing_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_synthesizing_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_synthesizing_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_synthesizing),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(
                 ret,
@@ -306,12 +319,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.synthesizer_completed_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_completed_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_completed_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_completed),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_completed_cb error")?;
             Ok(())
@@ -322,12 +335,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.synthesizer_canceled_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_canceled_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_canceled_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_canceled),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_canceled_cb error")?;
             Ok(())
@@ -338,12 +351,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisWordBoundaryEvent) + 'static + Send,
     {
-        self.synthesizer_word_boundary_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_word_boundary_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_word_boundary_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_word_boundary),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(
                 ret,
@@ -357,12 +370,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisVisemeEvent) + 'static + Send,
     {
-        self.synthesizer_viseme_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_viseme_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_viseme_received_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_viseme),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_viseme_cb error")?;
             Ok(())
@@ -373,12 +386,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisBookmarkEvent) + 'static + Send,
     {
-        self.synthesizer_bookmark_cb = Some(Box::new(f));
+        self.callbacks.synthesizer_bookmark_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_bookmark_reached_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_bookmark),
-                self as *const _ as *mut c_void,
+                &*self.callbacks as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_bookmark_cb error")?;
             Ok(())
@@ -393,8 +406,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_started called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_started_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_started_cb {
             trace!("synthesizer_started_cb defined");
             match SpeechSynthesisEvent::from_handle(hevent) {
                 Ok(event) => {
@@ -419,8 +432,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_synthesizing called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_synthesizing_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_synthesizing_cb {
             trace!("synthesizer_synthesizing_cb defined");
             match SpeechSynthesisEvent::from_handle(hevent) {
                 Ok(event) => {
@@ -445,8 +458,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_completed called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_completed_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_completed_cb {
             trace!("synthesizer_completed_cb defined");
             match SpeechSynthesisEvent::from_handle(hevent) {
                 Ok(event) => {
@@ -471,8 +484,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_canceled called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_canceled_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_canceled_cb {
             trace!("synthesizer_canceled_cb defined");
             match SpeechSynthesisEvent::from_handle(hevent) {
                 Ok(event) => {
@@ -497,8 +510,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_word_boundary called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_word_boundary_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_word_boundary_cb {
             trace!("synthesizer_word_boundary_cb defined");
             match SpeechSynthesisWordBoundaryEvent::from_handle(hevent) {
                 Ok(event) => {
@@ -523,8 +536,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_viseme called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_viseme_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_viseme_cb {
             trace!("synthesizer_viseme_cb defined");
             match SpeechSynthesisVisemeEvent::from_handle(hevent) {
                 Ok(event) => {
@@ -549,8 +562,8 @@ impl SpeechSynthesizer {
         pvContext: *mut c_void,
     ) {
         trace!("SpeechSynthesizer::cb_synthesizer_bookmark called");
-        let speech_synthesizer = &mut *(pvContext as *mut SpeechSynthesizer);
-        if let Some(cb) = &speech_synthesizer.synthesizer_bookmark_cb {
+        let callback_bag = &mut *(pvContext as *mut CallbackBag);
+        if let Some(cb) = &callback_bag.synthesizer_bookmark_cb {
             trace!("synthesizer_bookmark_cb defined");
             match SpeechSynthesisBookmarkEvent::from_handle(hevent) {
                 Ok(event) => {

--- a/src/speech/speech_synthesizer.rs
+++ b/src/speech/speech_synthesizer.rs
@@ -43,7 +43,7 @@ struct CallbackBag {
 pub struct SpeechSynthesizer {
     handle: SmartHandle<SPXSYNTHHANDLE>,
     properties: PropertyCollection,
-    callbacks: Box<CallbackBag>,
+    callback_bag: Box<CallbackBag>,
 }
 
 // to allow to move synthetizer to tokio::spawn
@@ -82,7 +82,7 @@ impl SpeechSynthesizer {
                 // Here we return a boxed instance of the CallbackBag,
                 // ensure that the pointer we provide to the C library
                 // points to a stable, heap-allocated location that holds the callbacks.
-                callbacks: Box::new(CallbackBag {
+                callback_bag: Box::new(CallbackBag {
                     synthesizer_started_cb: None,
                     synthesizer_synthesizing_cb: None,
                     synthesizer_completed_cb: None,
@@ -284,12 +284,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_started_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_started_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_started_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_started),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_started_cb error")?;
             Ok(())
@@ -300,12 +300,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_synthesizing_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_synthesizing_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_synthesizing_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_synthesizing),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(
                 ret,
@@ -319,12 +319,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_completed_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_completed_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_completed_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_completed),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_completed_cb error")?;
             Ok(())
@@ -335,12 +335,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_canceled_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_canceled_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_canceled_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_canceled),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_canceled_cb error")?;
             Ok(())
@@ -351,12 +351,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisWordBoundaryEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_word_boundary_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_word_boundary_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_word_boundary_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_word_boundary),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(
                 ret,
@@ -370,12 +370,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisVisemeEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_viseme_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_viseme_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_viseme_received_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_viseme),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_viseme_cb error")?;
             Ok(())
@@ -386,12 +386,12 @@ impl SpeechSynthesizer {
     where
         F: Fn(SpeechSynthesisBookmarkEvent) + 'static + Send,
     {
-        self.callbacks.synthesizer_bookmark_cb = Some(Box::new(f));
+        self.callback_bag.synthesizer_bookmark_cb = Some(Box::new(f));
         unsafe {
             let ret = synthesizer_bookmark_reached_set_callback(
                 self.handle.inner(),
                 Some(Self::cb_synthesizer_bookmark),
-                &*self.callbacks as *const _ as *mut c_void,
+                &*self.callback_bag as *const _ as *mut c_void,
             );
             convert_err(ret, "SpeechSynthesizer.set_synthesizer_bookmark_cb error")?;
             Ok(())

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,127 @@
+#![allow(dead_code)]
+use cognitive_services_speech_sdk_rs::audio::{
+    AudioConfig, AudioStreamFormat, PullAudioInputStream, PullAudioOutputStream,
+    PushAudioOutputStream,
+};
+use cognitive_services_speech_sdk_rs::speech::{SpeechConfig, SpeechRecognizer, SpeechSynthesizer};
+use log::*;
+use std::env;
+use std::path::PathBuf;
+
+pub(crate) fn get_sample_file(file_name: &str) -> String {
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let mut file_path = PathBuf::from(&current_dir);
+    file_path.push("examples");
+    file_path.push("sample_files");
+    file_path.push(file_name);
+    file_path.into_os_string().into_string().unwrap()
+}
+
+/// creates speech recognizer from pull input stream and MS speech subscription key
+/// returns recognizer and also pull stream so that data push can be initiated
+pub(crate) fn speech_recognizer_from_pull_stream() -> (SpeechRecognizer, PullAudioInputStream) {
+    let wave_format = AudioStreamFormat::get_wave_format_pcm(16000, None, None).unwrap();
+    let pull_stream = PullAudioInputStream::from_format(&wave_format).unwrap();
+    let audio_config = AudioConfig::from_stream_input(&pull_stream).unwrap();
+    (speech_recognizer_from_audio_cfg(audio_config), pull_stream)
+}
+
+/// creates speech recognizer from wav input file and MS speech subscription key
+pub(crate) fn speech_recognizer_from_wav_file(wav_file: &str) -> SpeechRecognizer {
+    let audio_config = AudioConfig::from_wav_file_input(wav_file).unwrap();
+    speech_recognizer_from_audio_cfg(audio_config)
+}
+
+///creates speech recognizer from provided audio config and implicit speech config
+/// created from MS subscription key hardcoded in sample file
+pub(crate) fn speech_recognizer_from_audio_cfg(audio_config: AudioConfig) -> SpeechRecognizer {
+    let speech_config = SpeechConfig::from_subscription(
+        env::var("MSSubscriptionKey").unwrap(),
+        env::var("MSServiceRegion").unwrap(),
+    )
+    .unwrap();
+
+    SpeechRecognizer::from_config(speech_config, audio_config).unwrap()
+}
+
+pub(crate) fn set_recognizer_callbacks(speech_recognizer: &mut SpeechRecognizer) {
+    speech_recognizer
+        .set_session_started_cb(|event| info!(">set_session_started_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_session_stopped_cb(|event| info!(">set_session_stopped_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_speech_start_detected_cb(|event| info!(">set_speech_start_detected_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_speech_end_detected_cb(|event| info!(">set_speech_end_detected_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_recognizing_cb(|event| info!(">set_recognizing_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_recognized_cb(|event| info!(">set_recognized_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_canceled_cb(|event| info!(">set_canceled_cb {event:?}"))
+        .unwrap();
+}
+
+///creates speech synthesizer from provided audio config and implicit speech config
+/// created from MS subscription key hardcoded in sample file
+pub(crate) fn speech_synthesizer_pull() -> (SpeechSynthesizer, PullAudioOutputStream) {
+    let pull_stream = PullAudioOutputStream::create_pull_stream().unwrap();
+    let audio_config = AudioConfig::from_stream_output(&pull_stream).unwrap();
+
+    let speech_config = SpeechConfig::from_subscription(
+        env::var("MSSubscriptionKey").unwrap(),
+        env::var("MSServiceRegion").unwrap(),
+    )
+    .unwrap();
+    let speech_synthesizer = SpeechSynthesizer::from_config(speech_config, audio_config).unwrap();
+    (speech_synthesizer, pull_stream)
+}
+
+pub(crate) fn speech_synthesizer_push() -> (SpeechSynthesizer, PushAudioOutputStream) {
+    let push_stream = PushAudioOutputStream::create_push_stream().unwrap();
+    let audio_config = AudioConfig::from_stream_output(&push_stream).unwrap();
+
+    let speech_config = SpeechConfig::from_subscription(
+        env::var("MSSubscriptionKey").unwrap(),
+        env::var("MSServiceRegion").unwrap(),
+    )
+    .unwrap();
+    let speech_synthesizer = SpeechSynthesizer::from_config(speech_config, audio_config).unwrap();
+    (speech_synthesizer, push_stream)
+}
+
+pub(crate) fn set_synthesizer_callbacks(speech_synthesizer: &mut SpeechSynthesizer) {
+    speech_synthesizer
+        .set_synthesizer_started_cb(|event| info!(">synthesizer_started_cb {event:?}"))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_synthesizing_cb(|event| info!(">synthesizer_synthesizing_cb {event:?}"))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_completed_cb(|event| info!(">synthesizer_completed_cb {event:?}"))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_canceled_cb(|event| info!(">synthesizer_canceled_cb {event:?}"))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_word_boundary_cb(|event| {
+            info!(">set_synthesizer_word_boundary_cb {event:?}")
+        })
+        .unwrap();
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,10 +1,6 @@
-use cognitive_services_speech_sdk_rs::audio::{AudioConfig, PullAudioOutputStream};
-use cognitive_services_speech_sdk_rs::speech::{SpeechConfig, SpeechRecognizer, SpeechSynthesizer};
 use log::{error, *};
-use std::env;
-use std::path::PathBuf;
-use std::time::Duration;
-use tokio::time::sleep;
+mod common;
+use common::*;
 
 #[tokio::test]
 async fn speech_to_text() {
@@ -14,7 +10,7 @@ async fn speech_to_text() {
     set_recognizer_callbacks(&mut speech_recognizer);
 
     let result = speech_recognizer.recognize_once_async().await.unwrap();
-    info!("got recognition {:?}", result);
+    info!("got recognition {result:?}");
     assert!(
         result
             .text
@@ -34,182 +30,10 @@ async fn text_to_speech() {
     set_synthesizer_callbacks(&mut speech_synthesizer);
 
     match speech_synthesizer.speak_text_async("Hello Rust!").await {
-        Err(err) => error!("speak_text_async error {:?}", err),
+        Err(err) => error!("speak_text_async error {err:?}"),
         Ok(speech_audio_bytes) => {
-            info!("speech_audio_bytes {:?}", speech_audio_bytes);
-            assert!(speech_audio_bytes.audio_data.len() > 0);
+            info!("speech_audio_bytes {speech_audio_bytes:?}");
+            assert!(!speech_audio_bytes.audio_data.is_empty());
         }
     }
-}
-
-#[tokio::test]
-async fn stt_segfault_test() {
-    let mut stt = Stt::new();
-    stt.start().await;
-
-    sleep(Duration::from_secs(5)).await;
-
-    stt.stop().await;
-}
-
-struct Stt {
-    recognizer: SpeechRecognizer,
-}
-
-#[tokio::test]
-async fn tts_segfault_test() {
-    let tts = Tts::new();
-    tts.start("In Rust, we trust.").await;
-
-    sleep(Duration::from_secs(5)).await;
-
-    tts.stop().await;
-}
-
-fn get_sample_file(file_name: &str) -> String {
-    let current_dir = std::env::current_dir().expect("Failed to get current directory");
-    let mut file_path = PathBuf::from(&current_dir);
-    file_path.push("examples");
-    file_path.push("sample_files");
-    file_path.push(file_name);
-    file_path.into_os_string().into_string().unwrap()
-}
-
-impl Stt {
-    fn new() -> Self {
-        let file_path_str = &get_sample_file("turn_on_the_lamp.wav");
-        let mut speech_recognizer = speech_recognizer_from_wav_file(file_path_str);
-
-        set_recognizer_callbacks(&mut speech_recognizer);
-
-        Self {
-            recognizer: speech_recognizer,
-        }
-    }
-
-    async fn start(&mut self) {
-        if let Err(err) = self.recognizer.start_continuous_recognition_async().await {
-            error!("start_continuous_recognition_async error {err:?}");
-        }
-    }
-
-    async fn stop(&mut self) {
-        if let Err(err) = self.recognizer.stop_continuous_recognition_async().await {
-            error!("stop_continuous_recognition_async error {err:?}");
-        }
-    }
-}
-
-struct Tts {
-    client: SpeechSynthesizer,
-}
-
-impl Tts {
-    pub fn new() -> Self {
-        let (mut speech_synthesizer, _) = speech_synthesizer_pull();
-
-        set_synthesizer_callbacks(&mut speech_synthesizer);
-
-        Self {
-            client: speech_synthesizer,
-        }
-    }
-
-    async fn start(&self, text: &str) {
-        let result = self.client.start_speaking_text_async(text).await.unwrap();
-        info!("Synthesis result: {result:?}");
-    }
-
-    async fn stop(&self) {
-        if let Err(err) = self.client.stop_speaking_async().await {
-            error!("stop_speaking_async error {err:?}");
-        }
-    }
-}
-
-/// creates speech recognizer from wav input file and MS speech subscription key
-fn speech_recognizer_from_wav_file(wav_file: &str) -> SpeechRecognizer {
-    let audio_config = AudioConfig::from_wav_file_input(wav_file).unwrap();
-    speech_recognizer_from_audio_cfg(audio_config)
-}
-
-///creates speech recognizer from provided audio config and implicit speech config
-/// created from MS subscription key hardcoded in sample file
-fn speech_recognizer_from_audio_cfg(audio_config: AudioConfig) -> SpeechRecognizer {
-    let speech_config = SpeechConfig::from_subscription(
-        env::var("MSSubscriptionKey").unwrap(),
-        env::var("MSServiceRegion").unwrap(),
-    )
-    .unwrap();
-
-    SpeechRecognizer::from_config(speech_config, audio_config).unwrap()
-}
-
-fn set_recognizer_callbacks(speech_recognizer: &mut SpeechRecognizer) {
-    speech_recognizer
-        .set_session_started_cb(|event| info!(">set_session_started_cb {event:?}"))
-        .unwrap();
-
-    speech_recognizer
-        .set_session_stopped_cb(|event| info!(">set_session_stopped_cb {event:?}"))
-        .unwrap();
-
-    speech_recognizer
-        .set_speech_start_detected_cb(|event| info!(">set_speech_start_detected_cb {event:?}"))
-        .unwrap();
-
-    speech_recognizer
-        .set_speech_end_detected_cb(|event| info!(">set_speech_end_detected_cb {event:?}"))
-        .unwrap();
-
-    speech_recognizer
-        .set_recognizing_cb(|event| info!(">set_recognizing_cb {event:?}"))
-        .unwrap();
-
-    speech_recognizer
-        .set_recognized_cb(|event| info!(">set_recognized_cb {event:?}"))
-        .unwrap();
-
-    speech_recognizer
-        .set_canceled_cb(|event| info!(">set_canceled_cb {event:?}"))
-        .unwrap();
-}
-
-///creates speech synthesizer from provided audio config and implicit speech config
-/// created from MS subscription key hardcoded in sample file
-pub fn speech_synthesizer_pull() -> (SpeechSynthesizer, PullAudioOutputStream) {
-    let pull_stream = PullAudioOutputStream::create_pull_stream().unwrap();
-    let audio_config = AudioConfig::from_stream_output(&pull_stream).unwrap();
-
-    let speech_config = SpeechConfig::from_subscription(
-        env::var("MSSubscriptionKey").unwrap(),
-        env::var("MSServiceRegion").unwrap(),
-    )
-    .unwrap();
-    let speech_synthesizer = SpeechSynthesizer::from_config(speech_config, audio_config).unwrap();
-    (speech_synthesizer, pull_stream)
-}
-
-pub fn set_synthesizer_callbacks(speech_synthesizer: &mut SpeechSynthesizer) {
-    speech_synthesizer
-        .set_synthesizer_started_cb(|event| info!(">synthesizer_started_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_synthesizing_cb(|event| info!(">synthesizer_synthesizing_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_completed_cb(|event| info!(">synthesizer_completed_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_canceled_cb(|event| info!(">synthesizer_canceled_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_word_boundary_cb(|event| {
-            info!(">set_synthesizer_word_boundary_cb {:?}", event)
-        })
-        .unwrap();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,64 +1,20 @@
-use cognitive_services_speech_sdk_rs as msspeech;
-use log::*;
-use rust_embed::Embed;
+use cognitive_services_speech_sdk_rs::audio::{AudioConfig, PullAudioOutputStream};
+use cognitive_services_speech_sdk_rs::speech::{SpeechConfig, SpeechRecognizer, SpeechSynthesizer};
+use log::{error, *};
 use std::env;
 use std::path::PathBuf;
-
-#[derive(Embed)]
-#[folder = "examples/sample_files"]
-struct Asset;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn speech_to_text() {
-    let current_dir = std::env::current_dir().expect("Failed to get current directory");
-    let mut file_path = PathBuf::from(&current_dir);
-    file_path.push("examples");
-    file_path.push("sample_files");
-    file_path.push("myVoiceIsMyPassportVerifyMe01.wav");
-    let file_path_str = &file_path.into_os_string().into_string().unwrap();
-    let audio_config = msspeech::audio::AudioConfig::from_wav_file_input(file_path_str).unwrap();
+    let file_path_str = &get_sample_file("myVoiceIsMyPassportVerifyMe01.wav");
+    let mut speech_recognizer = speech_recognizer_from_wav_file(file_path_str);
 
-    // before running this text export the below listed variables. Example:
-    // export MSSubscriptionKey=32...
-    // export MSServiceRegion=westeurope
-    let speech_config = msspeech::speech::SpeechConfig::from_subscription(
-        env::var("MSSubscriptionKey").unwrap(),
-        env::var("MSServiceRegion").unwrap_or("westeurope".to_string()),
-    )
-    .unwrap();
-    let mut speech_recognizer =
-        msspeech::speech::SpeechRecognizer::from_config(speech_config, audio_config).unwrap();
-
-    speech_recognizer
-        .set_session_started_cb(|event| info!("set_session_started_cb {:?}", event))
-        .unwrap();
-
-    speech_recognizer
-        .set_session_stopped_cb(|event| info!("set_session_stopped_cb {:?}", event))
-        .unwrap();
-
-    speech_recognizer
-        .set_speech_start_detected_cb(|event| info!("set_speech_start_detected_cb {:?}", event))
-        .unwrap();
-
-    speech_recognizer
-        .set_speech_end_detected_cb(|event| info!("set_speech_end_detected_cb {:?}", event))
-        .unwrap();
-
-    speech_recognizer
-        .set_recognizing_cb(|event| info!("set_recognizing_cb {:?}", event.result.text))
-        .unwrap();
-
-    speech_recognizer
-        .set_recognized_cb(|event| info!("set_recognized_cb {:?}", event))
-        .unwrap();
-
-    speech_recognizer
-        .set_canceled_cb(|event| info!("set_canceled_cb {:?}", event))
-        .unwrap();
+    set_recognizer_callbacks(&mut speech_recognizer);
 
     let result = speech_recognizer.recognize_once_async().await.unwrap();
-    println!("got recognition {:?}", result);
+    info!("got recognition {:?}", result);
     assert!(
         result
             .text
@@ -73,41 +29,187 @@ async fn speech_to_text() {
 
 #[tokio::test]
 async fn text_to_speech() {
-    let pull_stream = msspeech::audio::PullAudioOutputStream::create_pull_stream().unwrap();
-    let audio_config = msspeech::audio::AudioConfig::from_stream_output(&pull_stream).unwrap();
+    let (mut speech_synthesizer, _) = speech_synthesizer_pull();
 
-    // before running this text export the below listed variables. Example:
-    // export MSSubscriptionKey=32...
-    // export MSServiceRegion=westeurope
-    // cargo test
-    let speech_config = msspeech::speech::SpeechConfig::from_subscription(
-        env::var("MSSubscriptionKey").unwrap(),
-        env::var("MSServiceRegion").unwrap(),
-    )
-    .unwrap();
-    let mut speech_synthesizer =
-        msspeech::speech::SpeechSynthesizer::from_config(speech_config, audio_config).unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_started_cb(|event| info!("synthesizer_started_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_synthesizing_cb(|event| info!("synthesizer_synthesizing_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_completed_cb(|event| info!("synthesizer_completed_cb {:?}", event))
-        .unwrap();
-
-    speech_synthesizer
-        .set_synthesizer_canceled_cb(|event| info!("synthesizer_canceled_cb {:?}", event))
-        .unwrap();
+    set_synthesizer_callbacks(&mut speech_synthesizer);
 
     match speech_synthesizer.speak_text_async("Hello Rust!").await {
         Err(err) => error!("speak_text_async error {:?}", err),
         Ok(speech_audio_bytes) => {
             info!("speech_audio_bytes {:?}", speech_audio_bytes);
+            assert!(speech_audio_bytes.audio_data.len() > 0);
         }
     }
+}
+
+#[tokio::test]
+async fn stt_segfault_test() {
+    let mut stt = Stt::new();
+    stt.start().await;
+
+    sleep(Duration::from_secs(5)).await;
+
+    stt.stop().await;
+}
+
+struct Stt {
+    recognizer: SpeechRecognizer,
+}
+
+#[tokio::test]
+async fn tts_segfault_test() {
+    let tts = Tts::new();
+    tts.start("In Rust, we trust.").await;
+
+    sleep(Duration::from_secs(5)).await;
+
+    tts.stop().await;
+}
+
+fn get_sample_file(file_name: &str) -> String {
+    let current_dir = std::env::current_dir().expect("Failed to get current directory");
+    let mut file_path = PathBuf::from(&current_dir);
+    file_path.push("examples");
+    file_path.push("sample_files");
+    file_path.push(file_name);
+    file_path.into_os_string().into_string().unwrap()
+}
+
+impl Stt {
+    fn new() -> Self {
+        let file_path_str = &get_sample_file("turn_on_the_lamp.wav");
+        let mut speech_recognizer = speech_recognizer_from_wav_file(file_path_str);
+
+        set_recognizer_callbacks(&mut speech_recognizer);
+
+        Self {
+            recognizer: speech_recognizer,
+        }
+    }
+
+    async fn start(&mut self) {
+        if let Err(err) = self.recognizer.start_continuous_recognition_async().await {
+            error!("start_continuous_recognition_async error {err:?}");
+        }
+    }
+
+    async fn stop(&mut self) {
+        if let Err(err) = self.recognizer.stop_continuous_recognition_async().await {
+            error!("stop_continuous_recognition_async error {err:?}");
+        }
+    }
+}
+
+struct Tts {
+    client: SpeechSynthesizer,
+}
+
+impl Tts {
+    pub fn new() -> Self {
+        let (mut speech_synthesizer, _) = speech_synthesizer_pull();
+
+        set_synthesizer_callbacks(&mut speech_synthesizer);
+
+        Self {
+            client: speech_synthesizer,
+        }
+    }
+
+    async fn start(&self, text: &str) {
+        let result = self.client.start_speaking_text_async(text).await.unwrap();
+        info!("Synthesis result: {result:?}");
+    }
+
+    async fn stop(&self) {
+        if let Err(err) = self.client.stop_speaking_async().await {
+            error!("stop_speaking_async error {err:?}");
+        }
+    }
+}
+
+/// creates speech recognizer from wav input file and MS speech subscription key
+fn speech_recognizer_from_wav_file(wav_file: &str) -> SpeechRecognizer {
+    let audio_config = AudioConfig::from_wav_file_input(wav_file).unwrap();
+    speech_recognizer_from_audio_cfg(audio_config)
+}
+
+///creates speech recognizer from provided audio config and implicit speech config
+/// created from MS subscription key hardcoded in sample file
+fn speech_recognizer_from_audio_cfg(audio_config: AudioConfig) -> SpeechRecognizer {
+    let speech_config = SpeechConfig::from_subscription(
+        env::var("MSSubscriptionKey").unwrap(),
+        env::var("MSServiceRegion").unwrap(),
+    )
+    .unwrap();
+
+    SpeechRecognizer::from_config(speech_config, audio_config).unwrap()
+}
+
+fn set_recognizer_callbacks(speech_recognizer: &mut SpeechRecognizer) {
+    speech_recognizer
+        .set_session_started_cb(|event| info!(">set_session_started_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_session_stopped_cb(|event| info!(">set_session_stopped_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_speech_start_detected_cb(|event| info!(">set_speech_start_detected_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_speech_end_detected_cb(|event| info!(">set_speech_end_detected_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_recognizing_cb(|event| info!(">set_recognizing_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_recognized_cb(|event| info!(">set_recognized_cb {event:?}"))
+        .unwrap();
+
+    speech_recognizer
+        .set_canceled_cb(|event| info!(">set_canceled_cb {event:?}"))
+        .unwrap();
+}
+
+///creates speech synthesizer from provided audio config and implicit speech config
+/// created from MS subscription key hardcoded in sample file
+pub fn speech_synthesizer_pull() -> (SpeechSynthesizer, PullAudioOutputStream) {
+    let pull_stream = PullAudioOutputStream::create_pull_stream().unwrap();
+    let audio_config = AudioConfig::from_stream_output(&pull_stream).unwrap();
+
+    let speech_config = SpeechConfig::from_subscription(
+        env::var("MSSubscriptionKey").unwrap(),
+        env::var("MSServiceRegion").unwrap(),
+    )
+    .unwrap();
+    let speech_synthesizer = SpeechSynthesizer::from_config(speech_config, audio_config).unwrap();
+    (speech_synthesizer, pull_stream)
+}
+
+pub fn set_synthesizer_callbacks(speech_synthesizer: &mut SpeechSynthesizer) {
+    speech_synthesizer
+        .set_synthesizer_started_cb(|event| info!(">synthesizer_started_cb {:?}", event))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_synthesizing_cb(|event| info!(">synthesizer_synthesizing_cb {:?}", event))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_completed_cb(|event| info!(">synthesizer_completed_cb {:?}", event))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_canceled_cb(|event| info!(">synthesizer_canceled_cb {:?}", event))
+        .unwrap();
+
+    speech_synthesizer
+        .set_synthesizer_word_boundary_cb(|event| {
+            info!(">set_synthesizer_word_boundary_cb {:?}", event)
+        })
+        .unwrap();
 }

--- a/tests/pull_input_segfault_test.rs
+++ b/tests/pull_input_segfault_test.rs
@@ -1,0 +1,125 @@
+use std::{fs::File, io::Read, time::Duration};
+
+use cognitive_services_speech_sdk_rs::{
+    audio::{PullAudioInputStream, PullAudioInputStreamCallbacks},
+    error::Result,
+    speech::SpeechRecognizer,
+};
+use log::{debug, error, trace};
+use tokio::time::sleep;
+
+mod common;
+use common::*;
+
+/// simple binary data reader (no error handling at all!)
+/// acting as PullAudioInputStream for speech recognizer
+/// reading is not optimized at all. The only purpouse is to
+/// demonstrate usage of PullAudioInputStream
+struct BinaryAudioStreamReader {
+    file: File,
+}
+
+impl BinaryAudioStreamReader {
+    pub fn from_file(filename: &str) -> Self {
+        BinaryAudioStreamReader {
+            file: File::open(filename).unwrap(),
+        }
+    }
+}
+
+impl PullAudioInputStreamCallbacks for BinaryAudioStreamReader {
+    fn read(&mut self, data_buffer: &mut [u8]) -> u32 {
+        debug!("BinaryAudioStreamReader.read called {}", data_buffer.len());
+
+        let size = data_buffer.len();
+
+        // take at most 'size' bytes and read them into data_buffer
+        let mut internal_buffer = Vec::with_capacity(size);
+
+        let file_ref = &mut self.file;
+        let bytes_read: usize = file_ref
+            .take(size as u64)
+            .read_to_end(&mut internal_buffer)
+            .unwrap();
+
+        // if we read less then data_buffer length
+        // we need to extend internal_buffer to same length
+        // as clone_from_slice requires both slices to have
+        // same length
+        let diff = size - bytes_read;
+        if bytes_read < size {
+            for _ in 0..diff {
+                internal_buffer.push(0);
+            }
+        }
+
+        trace!(
+            "BinaryAudioStreamReader.internal_buffer {} {}",
+            internal_buffer.len(),
+            bytes_read
+        );
+        // copy read data into target data buffer
+        data_buffer.clone_from_slice(&internal_buffer[..]);
+
+        bytes_read as u32
+    }
+
+    fn close(&mut self) {
+        // nothing to do
+        debug!("BinaryAudioStreamReader.close called");
+    }
+
+    #[allow(unused_variables)]
+    fn get_property(&mut self, id: i32) -> Result<String> {
+        debug!("BinaryAudioStreamReader.get_property called {id}");
+        Ok("".to_owned())
+    }
+}
+
+struct Stt {
+    recognizer: SpeechRecognizer,
+    // keep the audio stream alive
+    _audio_stream: PullAudioInputStream,
+}
+
+impl Stt {
+    fn new() -> Self {
+        let filename = get_sample_file("turn_on_the_lamp.wav");
+        let (speech_recognizer, mut audio_pull_stream) = speech_recognizer_from_pull_stream();
+
+        let reg_all_stream_callbacks = true;
+        audio_pull_stream
+            .set_callbacks(
+                Box::new(BinaryAudioStreamReader::from_file(&filename)),
+                reg_all_stream_callbacks,
+            )
+            .unwrap();
+
+        Self {
+            recognizer: speech_recognizer,
+            _audio_stream: audio_pull_stream,
+        }
+    }
+
+    async fn start(&mut self) {
+        if let Err(err) = self.recognizer.start_continuous_recognition_async().await {
+            error!("start_continuous_recognition_async error {err:?}");
+        }
+    }
+
+    async fn stop(&mut self) {
+        if let Err(err) = self.recognizer.stop_continuous_recognition_async().await {
+            error!("stop_continuous_recognition_async error {err:?}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn pull_input_audio_stream_segfault_test() {
+    let mut stt = Stt::new();
+    stt.start().await;
+
+    sleep(Duration::from_secs(5)).await;
+
+    stt.stop().await;
+}

--- a/tests/push_output_segfault_test.rs
+++ b/tests/push_output_segfault_test.rs
@@ -1,0 +1,96 @@
+use std::{sync::mpsc, time::Duration};
+
+use cognitive_services_speech_sdk_rs::{
+    audio::{PushAudioOutputStream, PushAudioOutputStreamCallbacks},
+    speech::SpeechSynthesizer,
+};
+use log::{error, info};
+use tokio::time::sleep;
+
+mod common;
+use common::*;
+
+struct BinaryAudioStreamWriter {
+    final_audio_data: Vec<u8>,
+    sender: mpsc::Sender<Vec<u8>>,
+}
+
+impl BinaryAudioStreamWriter {
+    pub fn new(sender: mpsc::Sender<Vec<u8>>) -> Self {
+        BinaryAudioStreamWriter {
+            final_audio_data: vec![],
+            sender,
+        }
+    }
+}
+
+impl PushAudioOutputStreamCallbacks for BinaryAudioStreamWriter {
+    fn write(&mut self, data_buffer: &[u8]) -> u32 {
+        info!("BinaryAudioStreamWriter::write called");
+        let mut data_buffer_vec = data_buffer.to_vec();
+        self.final_audio_data.append(&mut data_buffer_vec);
+        data_buffer_vec.len() as u32
+    }
+
+    fn close(&mut self) {
+        info!("BinaryAudioStreamWriter::close called");
+        let audio_bytes = self.final_audio_data.clone();
+        self.sender.send(audio_bytes).unwrap();
+    }
+}
+
+struct Tts {
+    synthesizer: SpeechSynthesizer,
+    // Keep the audio push stream alive
+    _audio_push_stream: PushAudioOutputStream,
+}
+
+impl Tts {
+    pub fn new(tx: mpsc::Sender<Vec<u8>>) -> Self {
+        let (speech_synthesizer, mut audio_push_stream) = speech_synthesizer_push();
+
+        audio_push_stream
+            .set_callbacks(Box::new(BinaryAudioStreamWriter::new(tx)))
+            .unwrap();
+
+        Tts {
+            synthesizer: speech_synthesizer,
+            _audio_push_stream: audio_push_stream,
+        }
+    }
+
+    async fn start(&mut self) {
+        if let Err(err) = self
+            .synthesizer
+            .start_speaking_text_async("There's no place like home.")
+            .await
+        {
+            error!("audio_push_stream.start error {err:?}");
+        }
+    }
+
+    async fn stop(&mut self) {
+        if let Err(err) = self.synthesizer.stop_speaking_async().await {
+            error!("stop_speaking_async error {err:?}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn push_output_audio_stream_segfault_test() {
+    let (tx, rx) = mpsc::channel();
+
+    {
+        let mut tts = Tts::new(tx);
+        tts.start().await;
+
+        sleep(Duration::from_secs(5)).await;
+
+        tts.stop().await;
+    }
+
+    // Now the Tts instance is dropped and audio push stream is closed
+
+    let final_audio_data = rx.recv().unwrap();
+    assert!(!final_audio_data.is_empty());
+}

--- a/tests/recognizer_segfault_test.rs
+++ b/tests/recognizer_segfault_test.rs
@@ -1,0 +1,46 @@
+use cognitive_services_speech_sdk_rs::speech::SpeechRecognizer;
+use log::error;
+use std::time::Duration;
+use tokio::time::sleep;
+
+mod common;
+use common::*;
+
+#[tokio::test]
+async fn stt_segfault_test() {
+    let mut stt = Stt::new();
+    stt.start().await;
+
+    sleep(Duration::from_secs(5)).await;
+
+    stt.stop().await;
+}
+
+struct Stt {
+    recognizer: SpeechRecognizer,
+}
+
+impl Stt {
+    fn new() -> Self {
+        let file_path_str = &get_sample_file("turn_on_the_lamp.wav");
+        let mut speech_recognizer = speech_recognizer_from_wav_file(file_path_str);
+
+        set_recognizer_callbacks(&mut speech_recognizer);
+
+        Self {
+            recognizer: speech_recognizer,
+        }
+    }
+
+    async fn start(&mut self) {
+        if let Err(err) = self.recognizer.start_continuous_recognition_async().await {
+            error!("start_continuous_recognition_async error {err:?}");
+        }
+    }
+
+    async fn stop(&mut self) {
+        if let Err(err) = self.recognizer.stop_continuous_recognition_async().await {
+            error!("stop_continuous_recognition_async error {err:?}");
+        }
+    }
+}

--- a/tests/synthesizer_segfault_test.rs
+++ b/tests/synthesizer_segfault_test.rs
@@ -1,0 +1,48 @@
+mod common;
+use std::time::Duration;
+
+use cognitive_services_speech_sdk_rs::speech::SpeechSynthesizer;
+use common::*;
+use log::{error, info};
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn tts_segfault_test() {
+    let tts = Tts::new();
+    tts.start("In Rust, we trust.").await;
+
+    sleep(Duration::from_secs(5)).await;
+
+    tts.stop().await;
+}
+
+struct Tts {
+    synthesizer: SpeechSynthesizer,
+}
+
+impl Tts {
+    pub fn new() -> Self {
+        let (mut speech_synthesizer, _) = speech_synthesizer_pull();
+
+        set_synthesizer_callbacks(&mut speech_synthesizer);
+
+        Self {
+            synthesizer: speech_synthesizer,
+        }
+    }
+
+    async fn start(&self, text: &str) {
+        let result = self
+            .synthesizer
+            .start_speaking_text_async(text)
+            .await
+            .unwrap();
+        info!("Synthesis result: {result:?}");
+    }
+
+    async fn stop(&self) {
+        if let Err(err) = self.synthesizer.stop_speaking_async().await {
+            error!("stop_speaking_async error {err:?}");
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #33, it refactors how event callback closures are managed in both the `SpeechRecognizer` and `SpeechSynthesizer` structs.

Instead of storing callback closures directly in these structs, a new internal `CallbackBag` struct is introduced and **boxed**, ensuring that callbacks reside at a stable heap address. 

This change improves memory safety and allows the main structs to be moved freely without invalidating callback pointers. 

Checklist: 

 - [x] Fix the callbacks in `SpeechRecognizer` & add tests
 - [x] Fix `SpeechSynthesizer` & add tests
 - [x] Fix `PullAudioInputStream` & add tests
 - [x] Fix `PushAudioOutputStream` & add tests
 

